### PR TITLE
Migrate from OKD to OCP

### DIFF
--- a/.github/workflows/destroy-cluster.yaml
+++ b/.github/workflows/destroy-cluster.yaml
@@ -1,4 +1,4 @@
-name: Destroy an existing OKD cluster
+name: Destroy an existing OCP cluster
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/provision-cluster.yaml
+++ b/.github/workflows/provision-cluster.yaml
@@ -1,4 +1,4 @@
-name: Provision a new OKD cluster
+name: Provision a new OCP cluster
 on:
   workflow_dispatch:
     inputs:
@@ -13,9 +13,9 @@ on:
         required: true
       cluster-version:
         type: string
-        description: OKD version to install
+        description: OCP version to install
         required: true
-        default: "4.19"
+        default: "4.16"
       force:
         type: boolean
         description: |
@@ -63,7 +63,7 @@ jobs:
             INSTALL_ARGS=""
           fi
           ./install-cluster.sh --cluster ${{ inputs.cluster-name }} \
-              --okdVersion ${{ inputs.cluster-version }} \
+              --ocpVersion ${{ inputs.cluster-version }} \
               --controlPlaneNodes $CONTROL_PLANE_NODES \
               --computeNodes $COMPUTE_NODES \
               --log-level warn \

--- a/.github/workflows/provision-cluster.yaml
+++ b/.github/workflows/provision-cluster.yaml
@@ -15,7 +15,7 @@ on:
         type: string
         description: OCP version to install
         required: true
-        default: "4.16"
+        default: "4.19"
       force:
         type: boolean
         description: |

--- a/.github/workflows/test-registry-operator.yaml
+++ b/.github/workflows/test-registry-operator.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Install OpenShift cluster
         run: |
           ./install-cluster.sh --cluster $CLUSTER_NAME \
-              --okdVersion $OPENSHIFT_VERSION \
+              --ocpVersion $OPENSHIFT_VERSION \
               --controlPlaneNodes $CONTROL_PLANE_NODES \
               --computeNodes $COMPUTE_NODES \
               --log-level warn

--- a/.github/workflows/test-registry-release.yaml
+++ b/.github/workflows/test-registry-release.yaml
@@ -196,7 +196,7 @@ jobs:
         if: ${{ inputs.skipClusterInstall != 'true' }}
         run: |
           ./install-cluster.sh --cluster $CLUSTER_NAME \
-              --okdVersion $OPENSHIFT_VERSION \
+              --ocpVersion $OPENSHIFT_VERSION \
               --controlPlaneNodes $CONTROL_PLANE_NODES \
               --computeNodes $COMPUTE_NODES \
               --log-level warn
@@ -1735,7 +1735,7 @@ jobs:
 
       - name: Install OpenShift cluster
         run: |
-          ./install-cluster.sh --cluster $CLUSTER_NAME --okdVersion $OPENSHIFT_VERSION --controlPlaneNodes $CONTROL_PLANE_NODES --computeNodes $COMPUTE_NODES --log-level warn
+          ./install-cluster.sh --cluster $CLUSTER_NAME --ocpVersion $OPENSHIFT_VERSION --controlPlaneNodes $CONTROL_PLANE_NODES --computeNodes $COMPUTE_NODES --log-level warn
 
       - name: Install OpenShift Docker Pull Credentials
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /clusters/
 /logs/
 /okd-installers/
+/ocp-installers/
 /secrets.env
 /workflow-cache/
 /workflow-results/

--- a/configure-pull-secret.sh
+++ b/configure-pull-secret.sh
@@ -65,7 +65,7 @@ usage() {
     echo "  export DOCKER_PASSWORD=mypassword"
     echo "  export DOCKER_EMAIL=myuser@example.com"
     echo "  $0                        # Uses default cluster (\$USER)"
-    echo "  $0 --cluster okd419       # Uses specific cluster"
+    echo "  $0 --cluster ocp416       # Uses specific cluster"
     echo ""
     echo "Notes:"
     echo "  - The cluster must already exist and be properly configured"

--- a/docs/MIGRATE-TO-OCP.md
+++ b/docs/MIGRATE-TO-OCP.md
@@ -1,0 +1,632 @@
+# Migration Plan: OKD to OpenShift Container Platform (OCP)
+
+## Executive Summary
+
+This document outlines the migration strategy from OKD (community OpenShift) to Red Hat OpenShift
+Container Platform (OCP) for the Apicurio testing infrastructure.
+
+**Approach**: Hard cutover (complete replacement of OKD with OCP)
+**Timeline**: ASAP
+**Target Version**: OCP 4.16 (stable)
+**OKD Support**: Will be removed once OCP is validated
+
+---
+
+## Current State
+
+### Platform
+- **Current**: OKD versions 4.14, 4.16, 4.19
+- **Target**: OCP 4.16
+
+### Infrastructure
+- **Cloud Provider**: AWS (us-east-1)
+- **Instance Types**: m5.xlarge (4 vCPU, 16 GB RAM)
+- **Topology**: 3 control plane + 3 compute nodes
+- **Availability**: Single AZ (us-east-1a)
+- **DNS**: Route53 (apicurio-testing.org)
+
+### Testing Stack
+- Apicurio Registry (multiple storage backends)
+- Strimzi Kafka Operator
+- Keycloak for authentication
+- PostgreSQL and MySQL databases
+- Integration tests (Maven)
+- UI tests (Playwright)
+- DAST security scanning (RapiDAST)
+
+---
+
+## Migration Phases
+
+### Phase 1: Installer & Templates (Week 1, Days 1-2)
+
+#### 1.1 Create OCP Installer Download Script
+**File**: `download-ocp-installer.sh` (replaces `download-okd-installer.sh`)
+
+**Key Changes**:
+- Source: `mirror.openshift.com` instead of GitHub releases
+- Version format: `4.16.x` instead of `4.19.0-0.okd-scos-xxxx`
+- Binary name: `openshift-install`
+
+**Download URL Pattern**:
+```
+https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.16/openshift-install-linux.tar.gz
+```
+
+#### 1.2 Create OCP Install Config Templates
+**New Directory**: `templates/ocp/4.16/`
+**File**: `templates/ocp/4.16/install-config.yaml`
+
+**Key Differences from OKD**:
+```yaml
+# Add FIPS mode support (optional)
+fips: false
+
+# Pull secret MUST be from console.redhat.com
+pullSecret: '$OPENSHIFT_PULL_SECRET'
+
+# Platform metadata (OCP vs OKD)
+metadata:
+  name: '$CLUSTER_NAME'
+
+# AWS tags remain the same but update platform reference
+platform:
+  aws:
+    userTags:
+      apicurio/FromOcpInstaller: "true"  # Changed from OKD
+```
+
+#### 1.3 Update Core Installation Scripts
+**Files to Modify**:
+
+1. **`install-cluster.sh`**
+   - Replace OKD installer calls with OCP installer
+   - Update template path: `templates/okd/` → `templates/ocp/`
+   - Update version selection logic
+   - Change default version to 4.16
+
+2. **`generate-install-config.sh`**
+   - Update template directory path
+   - Validate OCP pull secret format
+   - Remove OKD-specific version handling
+
+3. **`shared.sh`**
+   - Update any platform detection functions
+   - Update version validation for OCP format
+
+4. **`configure-pull-secret.sh`**
+   - Ensure compatibility with Red Hat pull secret format
+   - Validate secret includes `cloud.openshift.com` registry
+
+---
+
+### Phase 2: Application Deployment (Week 1, Days 3-4)
+
+#### 2.1 Operator Compatibility Verification
+**Expected**: All operators should work without modification
+
+**Operators to Test**:
+- ✅ Apicurio Registry Operator
+- ✅ Strimzi Kafka Operator (versions 0.43, 0.47)
+- ✅ Keycloak Operator
+- ✅ PostgreSQL/MySQL deployments
+
+**Scripts (Expected No Changes)**:
+- `install-apicurio-operator.sh`
+- `install-apicurio-registry.sh`
+- `install-strimzi.sh`
+- `install-kafka.sh`
+- `install-keycloak-operator.sh`
+- `install-keycloak.sh`
+
+**Validation**:
+- Deploy each operator on OCP 4.16 cluster
+- Verify CRDs install correctly
+- Test all deployment profiles (inmemory, postgresql, mysql, kafkasql, authn)
+
+#### 2.2 Storage Configuration
+**Current**: Default AWS EBS storage class
+
+**For OCP**: Verify storage class names
+- OKD: `gp3-csi` or `gp2`
+- OCP: `gp3-csi` or `gp2` (should be identical on AWS)
+
+**Action**: No changes expected, but verify in templates
+
+#### 2.3 TLS Certificate Handling
+**Current**: Let's Encrypt + certbot + Route53 DNS challenge
+
+**For OCP**: Same process should work
+
+**Script**: `install-tls-cert.sh` (no changes expected)
+
+**Validation**:
+- Verify cert installation for `*.apps.$CLUSTER_NAME.apicurio-testing.org`
+- Test HTTPS access to applications
+
+---
+
+### Phase 3: CI/CD Pipeline Updates (Week 1, Days 4-5)
+
+#### 3.1 GitHub Actions Workflows
+
+**Files to Update**:
+
+1. **`.github/workflows/provision-cluster.yaml`**
+   - Update installer download to use OCP
+   - Update version input (default to 4.16)
+   - Update pull secret reference
+
+2. **`.github/workflows/destroy-cluster.yaml`**
+   - Update any OKD-specific resource tags
+   - Ensure AWS cleanup works for OCP clusters
+
+3. **`.github/workflows/test-registry-release.yaml`**
+   - Update matrix to use OCP versions
+   - Remove OKD version references
+   - Test with OCP 4.16 only initially
+
+**Example Workflow Changes**:
+```yaml
+# Before (OKD)
+inputs:
+  okd-version:
+    default: "4.19"
+    type: choice
+    options:
+      - "4.19"
+      - "4.16"
+      - "4.14"
+
+# After (OCP)
+inputs:
+  ocp-version:
+    default: "4.16"
+    type: choice
+    options:
+      - "4.16"
+      - "4.17"  # Future-proofing
+```
+
+#### 3.2 GitHub Secrets
+
+**Required Secrets** (verify these exist):
+- `OPENSHIFT_PULL_SECRET` - Update with Red Hat pull secret from console.redhat.com
+- `AWS_ACCESS_KEY_ID` - No change
+- `AWS_SECRET_ACCESS_KEY` - No change
+- `SSH_PUBLIC_KEY` - No change
+
+**Action**: Update `OPENSHIFT_PULL_SECRET` with OCP pull secret
+
+---
+
+### Phase 4: Testing & Validation (Week 1-2, Days 5-7)
+
+#### 4.1 Manual Testing Checklist
+
+**Cluster Provisioning**:
+- [ ] Download OCP 4.16 installer successfully
+- [ ] Generate install-config.yaml from template
+- [ ] Provision OCP 4.16 cluster on AWS
+- [ ] Verify cluster accessible via console
+- [ ] Verify DNS records created in Route53
+- [ ] Install TLS certificates
+- [ ] Verify HTTPS access to console
+
+**Application Deployment**:
+- [ ] Install Apicurio Registry Operator
+- [ ] Deploy Registry with inmemory profile
+- [ ] Deploy Registry with postgresql profile (PG 12, 16, 17)
+- [ ] Deploy Registry with mysql profile (MySQL 8.0, 8.4)
+- [ ] Deploy Registry with kafkasql profile (Strimzi 0.43, 0.47)
+- [ ] Deploy Registry with authn profile (Keycloak 22.0, 26.3.1)
+- [ ] Verify all deployments healthy
+
+**Test Suite Execution**:
+- [ ] Run integration tests (`./run-integration-tests.sh`)
+  - [ ] Smoke tests pass
+  - [ ] Full integration test suite passes
+  - [ ] Auth tests pass
+- [ ] Run UI tests (`./run-ui-tests.sh`)
+  - [ ] Upstream build tests pass
+  - [ ] Downstream build tests pass
+- [ ] Run DAST scans (`./run-dast-scan.sh`)
+  - [ ] Registry v2 API scan completes
+  - [ ] Registry v3 API scan completes
+  - [ ] Confluent compatibility scan completes
+
+**Log Collection**:
+- [ ] Verify `download-pod-logs.sh` works on OCP
+- [ ] Ensure logs saved to `/tmp/apicurio-testing-results/`
+
+#### 4.2 Automated Testing via GitHub Actions
+
+**Test Workflow**:
+- [ ] Trigger `provision-cluster.yaml` with OCP 4.16
+- [ ] Verify cluster provisions successfully
+- [ ] Trigger `test-registry-release.yaml`
+- [ ] Verify all test profiles pass
+- [ ] Trigger `destroy-cluster.yaml`
+- [ ] Verify cluster destroyed and AWS resources cleaned up
+
+#### 4.3 Performance Comparison
+
+**Metrics to Track**:
+| Metric | OKD 4.19 (Baseline) | OCP 4.16 (Target) | Delta |
+|--------|---------------------|-------------------|-------|
+| Cluster provision time | TBD | TBD | TBD |
+| Application deploy time | TBD | TBD | TBD |
+| Integration test duration | TBD | TBD | TBD |
+| UI test duration | TBD | TBD | TBD |
+| AWS hourly cost | TBD | TBD | TBD |
+
+**Action**: Run baseline OKD test, then compare with OCP
+
+---
+
+### Phase 5: Cutover & Cleanup (Week 2, Days 8-10)
+
+#### 5.1 Pre-Cutover Validation
+- [ ] All manual tests pass on OCP 4.16
+- [ ] All automated tests pass via GitHub Actions
+- [ ] Performance metrics acceptable
+- [ ] Documentation updated
+
+#### 5.2 Cutover Steps
+
+**Day 8: Update Default Configuration**
+1. Update all workflows to use OCP 4.16 by default
+2. Update documentation (README, scripts help text)
+3. Commit changes to main branch
+
+**Day 9: Remove OKD Artifacts**
+1. Delete `download-okd-installer.sh`
+2. Delete `templates/okd/` directory
+3. Remove OKD version options from scripts
+4. Update any remaining OKD references
+
+**Day 10: Final Validation**
+1. Run full test suite on OCP
+2. Monitor for any issues
+3. Document any gotchas or lessons learned
+
+#### 5.3 Cleanup Checklist
+
+**Files to Delete**:
+- [ ] `download-okd-installer.sh`
+- [ ] `templates/okd/4.14/install-config.yaml`
+- [ ] `templates/okd/4.16/install-config.yaml`
+- [ ] `templates/okd/4.19/install-config.yaml`
+- [ ] `templates/okd/` directory (entire)
+
+**Files to Update**:
+- [ ] `README.md` - Update platform references
+- [ ] `install-cluster.sh` - Remove OKD version options
+- [ ] `generate-install-config.sh` - Remove OKD template paths
+- [ ] `.github/workflows/provision-cluster.yaml` - Remove OKD versions
+- [ ] `.github/workflows/test-registry-release.yaml` - Remove OKD matrix
+
+**Rename Files** (if desired):
+- [ ] `download-ocp-installer.sh` → `download-installer.sh`
+
+---
+
+## Key Differences: OKD vs OCP
+
+### Technical Differences
+
+| Aspect | OKD | OCP |
+|--------|-----|-----|
+| **Source** | Community, GitHub releases | Red Hat, mirror.openshift.com |
+| **Versioning** | `4.19.0-0.okd-scos-xxx` | `4.16.20` |
+| **Pull Secret** | Generic Docker credentials | Red Hat account required |
+| **Support** | Community | Red Hat Enterprise Support |
+| **Release Cadence** | Follows upstream quickly | Stable, tested releases |
+| **FIPS Mode** | Not available | Available (optional) |
+| **Certification** | None | Red Hat certified operators |
+
+### Operational Differences
+
+| Aspect | OKD | OCP |
+|--------|-----|-----|
+| **Cost** | Free (AWS infrastructure only) | Requires RHEL subscription |
+| **Updates** | Manual, frequent | Controlled, tested |
+| **Operators** | Community + certified | Red Hat certified |
+| **SLA** | None | Enterprise SLA available |
+
+### For Apicurio Testing
+
+**Impact**: Minimal to none
+- Same Kubernetes APIs
+- Same AWS infrastructure
+- Same operators (Apicurio, Strimzi, Keycloak)
+- Same test frameworks
+
+**Benefits**:
+- More stable releases
+- Better support for troubleshooting
+- Aligned with Red Hat product testing
+- Red Hat certified operator ecosystem
+
+---
+
+## Risk Assessment
+
+### High Risk Items
+**None identified** - OCP and OKD are nearly identical for our use case
+
+### Medium Risk Items
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|-----------|------------|
+| Pull secret format issues | Cluster provision fails | Low | Test with OCP pull secret early |
+| Operator incompatibility | App deployment fails | Low | Test all operators before cutover |
+| Version mismatch issues | Unexpected behavior | Low | Use stable OCP 4.16 release |
+
+### Low Risk Items
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|-----------|------------|
+| GitHub Actions failures | CI/CD disruption | Low | Test workflows before merge |
+| DNS propagation delays | Temporary unavailability | Low | Keep same Route53 setup |
+| AWS quota limits | Provision failures | Very Low | Same resources as OKD |
+
+---
+
+## Rollback Plan
+
+### If OCP Migration Fails
+
+**Rollback Steps**:
+1. Revert commits to restore OKD scripts
+2. Restore `download-okd-installer.sh`
+3. Restore `templates/okd/` directory
+4. Update workflows back to OKD versions
+5. Document reason for rollback
+
+**Rollback Time**: < 1 hour (git revert)
+
+### When to Rollback
+
+Trigger rollback if:
+- Cannot provision OCP cluster after 3 attempts
+- Critical test failures on OCP that don't occur on OKD
+- Operator incompatibility discovered
+- Blocker issues with no workaround
+
+---
+
+## Success Criteria
+
+### Required for Cutover
+- [x] OCP 4.16 cluster provisions successfully
+- [ ] All Apicurio Registry profiles deploy successfully
+- [ ] Integration test suite passes (100% pass rate)
+- [ ] UI test suite passes (100% pass rate)
+- [ ] DAST scans complete without errors
+- [ ] GitHub Actions workflows execute successfully
+- [ ] Documentation updated
+
+### Post-Cutover Validation (Week 3)
+- [ ] 5 successful OCP cluster provisions via automation
+- [ ] 10 successful test suite runs
+- [ ] Zero rollbacks or critical issues
+- [ ] Team comfortable with OCP operations
+
+---
+
+## Timeline
+
+### Week 1: Implementation & Testing
+
+| Day | Activities | Owner | Status |
+|-----|-----------|-------|--------|
+| 1 | Create OCP installer script + templates | TBD | Pending |
+| 2 | Update core installation scripts | TBD | Pending |
+| 3 | Test operator deployments on OCP | TBD | Pending |
+| 4 | Update GitHub Actions workflows | TBD | Pending |
+| 5 | Run full manual test suite | TBD | Pending |
+| 6-7 | Run automated tests, collect metrics | TBD | Pending |
+
+### Week 2: Cutover & Cleanup
+
+| Day | Activities | Owner | Status |
+|-----|-----------|-------|--------|
+| 8 | Deploy to production, update defaults | TBD | Pending |
+| 9 | Remove OKD artifacts | TBD | Pending |
+| 10 | Final validation, documentation | TBD | Pending |
+
+### Week 3: Stabilization
+- Monitor OCP clusters
+- Address any issues
+- Collect feedback
+- Optimize as needed
+
+---
+
+## Implementation Order
+
+### Priority 1 (Must Have - Week 1)
+1. `download-ocp-installer.sh` - OCP installer download script
+2. `templates/ocp/4.16/install-config.yaml` - OCP cluster configuration
+3. Update `install-cluster.sh` - Core provisioning logic
+4. Update `generate-install-config.sh` - Template processing
+5. Manual test: Provision single OCP cluster
+
+### Priority 2 (Must Have - Week 1)
+6. Deploy all operators on OCP cluster
+7. Run integration tests
+8. Run UI tests
+9. Run DAST scans
+10. Validate all tests pass
+
+### Priority 3 (Must Have - Week 1-2)
+11. Update `.github/workflows/provision-cluster.yaml`
+12. Update `.github/workflows/test-registry-release.yaml`
+13. Update `.github/workflows/destroy-cluster.yaml`
+14. Test automated workflows
+
+### Priority 4 (Cleanup - Week 2)
+15. Remove OKD scripts and templates
+16. Update documentation
+17. Final validation
+
+---
+
+## Prerequisites Checklist
+
+### Red Hat Access
+- [x] Red Hat employee access
+- [ ] OCP pull secret obtained from console.redhat.com
+- [ ] Pull secret stored in GitHub Secrets (`OPENSHIFT_PULL_SECRET`)
+
+### AWS Infrastructure
+- [ ] AWS account access verified
+- [ ] Service quotas sufficient for OCP
+- [ ] Route53 hosted zone for `apicurio-testing.org` exists
+- [ ] AWS credentials configured in GitHub Secrets
+
+### Local Environment
+- [ ] AWS CLI installed and configured
+- [ ] `oc` CLI installed (OpenShift CLI)
+- [ ] Git repository cloned
+- [ ] Bash shell available
+
+---
+
+## Post-Migration Tasks
+
+### Documentation Updates
+- [ ] Update `README.md` with OCP references
+- [ ] Update script help text and comments
+- [ ] Create troubleshooting guide for OCP
+- [ ] Document OCP-specific configurations
+
+### Knowledge Transfer
+- [ ] Share OCP provisioning process with team
+- [ ] Document any OCP-specific gotchas
+- [ ] Update runbooks for OCP operations
+
+### Future Enhancements
+- [ ] Consider adding OCP 4.17 support
+- [ ] Explore OCP upgrades (4.16 → 4.17)
+- [ ] Evaluate disconnected/airgap installation for security testing
+- [ ] Consider multi-AZ deployments for HA testing
+
+---
+
+## Questions & Answers
+
+**Q: Why hard cutover vs parallel run?**
+A: Faster migration (ASAP requirement), no need to maintain two platforms, simpler codebase.
+
+**Q: What if we find issues with OCP?**
+A: Rollback plan in place (< 1 hour to revert), but risk is very low given OCP/OKD similarity.
+
+**Q: Will tests run differently on OCP?**
+A: No, same Kubernetes APIs and operators. Tests should be identical.
+
+**Q: What about cost?**
+A: Red Hat employees have access to OCP subscriptions. AWS infrastructure costs remain the same.
+
+**Q: Can we run OCP and OKD in parallel temporarily?**
+A: Not planned, but rollback plan allows returning to OKD if needed.
+
+---
+
+## Contact & Support
+
+**For OCP Technical Issues**:
+- Red Hat Support Portal: https://access.redhat.com
+- Internal Red Hat Slack channels
+
+**For Migration Questions**:
+- Repository maintainer: TBD
+- Slack channel: TBD
+
+---
+
+## Appendix A: OCP Installer Download URLs
+
+### Stable Releases
+```bash
+# OCP 4.16 (stable)
+https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.16/openshift-install-linux.tar.gz
+
+# OCP 4.17 (stable) - future
+https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable-4.17/openshift-install-linux.tar.gz
+```
+
+### Specific Versions
+```bash
+# Example: OCP 4.16.20
+https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.16.20/openshift-install-linux.tar.gz
+```
+
+### Latest Release
+```bash
+# Latest OCP release
+https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-install-linux.tar.gz
+```
+
+---
+
+## Appendix B: OCP Pull Secret Format
+
+### Obtaining the Pull Secret
+1. Navigate to: https://console.redhat.com/openshift/install/pull-secret
+2. Click "Copy pull secret"
+3. Store in GitHub Secrets as `OPENSHIFT_PULL_SECRET`
+
+### Pull Secret Structure
+```json
+{
+  "auths": {
+    "cloud.openshift.com": {
+      "auth": "...",
+      "email": "..."
+    },
+    "quay.io": {
+      "auth": "...",
+      "email": "..."
+    },
+    "registry.connect.redhat.com": {
+      "auth": "...",
+      "email": "..."
+    },
+    "registry.redhat.io": {
+      "auth": "...",
+      "email": "..."
+    }
+  }
+}
+```
+
+**Note**: OCP pull secret includes `cloud.openshift.com` and Red Hat registries, unlike generic Docker
+credentials used with OKD.
+
+---
+
+## Appendix C: Version Comparison Matrix
+
+| OKD Version | Release Date | OCP Equivalent | OCP Release Date | Notes |
+|-------------|--------------|----------------|------------------|-------|
+| 4.14.0-0.okd | 2023-11 | 4.14.x | 2023-11 | Kubernetes 1.27 |
+| 4.16.0-0.okd | 2024-07 | 4.16.x | 2024-06 | Kubernetes 1.29 |
+| 4.19.0-0.okd | 2025-01 | 4.17.x (future) | 2024-11 | Kubernetes 1.30 |
+
+**Migration Strategy**: Start with OCP 4.16 as it's the stable, well-tested release that aligns with OKD
+4.16 currently in use.
+
+---
+
+## Document History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2025-11-07 | Claude Code | Initial migration plan |
+
+---
+
+**Last Updated**: 2025-11-07
+**Status**: Draft - Ready for Implementation

--- a/download-ocp-installer.sh
+++ b/download-ocp-installer.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+
+# Script to download OCP installer
+# Usage: ./download-ocp-installer.sh --version <ocp-version>
+
+# Get the directory where this script is located
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$BASE_DIR/shared.sh"
+
+load_cache_config
+
+# Resolves OCP version to the latest stable or specific version
+# Usage: resolve_ocp_version "4.16"
+# Returns: The full version string to download (e.g., "stable-4.16")
+resolve_ocp_version() {
+    local desired_version="$1"
+
+    # Validate input
+    if [[ -z "$desired_version" ]]; then
+        echo "Error: No version specified" >&2
+        return 1
+    fi
+
+    # Validate version format (should be X.Y)
+    if [[ ! "$desired_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+        echo "Error: Version should be in format X.Y (e.g., 4.16)" >&2
+        return 1
+    fi
+
+    echo "Resolving OCP version $desired_version..." >&2
+
+    # For OCP, we use the stable release channel
+    # We can either use "stable-X.Y" or fetch specific versions
+    local version_string="stable-${desired_version}"
+
+    echo "Using stable release channel: $version_string" >&2
+    echo "$version_string"
+}
+
+# Gets the download URL for the OCP installer
+# Usage: get_ocp_download_url "stable-4.16"
+# Returns: The download URL for the openshift-install binary
+get_ocp_download_url() {
+    local version_string="$1"
+
+    if [[ -z "$version_string" ]]; then
+        echo "Error: No version specified" >&2
+        return 1
+    fi
+
+    echo "Getting download URL for OCP version $version_string..." >&2
+
+    # OCP installer is hosted on Red Hat's mirror site
+    local base_url="https://mirror.openshift.com/pub/openshift-v4/clients/ocp"
+    local download_url="${base_url}/${version_string}/openshift-install-linux.tar.gz"
+
+    echo "Download URL: $download_url" >&2
+    echo "$download_url"
+}
+
+# Downloads and extracts the OCP installer
+# Usage: download_ocp_installer "4.16"
+# Returns: 0 on success, 1 on failure
+download_ocp_installer() {
+    local ocp_version="$1"
+
+    if [[ -z "$ocp_version" ]]; then
+        echo "Error: Version required." >&2
+        return 1
+    fi
+
+    local version_string
+    version_string=$(resolve_ocp_version "$ocp_version")
+    if [[ $? -ne 0 ]]; then
+        return 1
+    fi
+
+    local output_dir
+    output_dir="$BIN_DIR/$version_string"
+    mkdir -p "$output_dir"
+
+    local link_dir
+    link_dir="$BIN_DIR/$ocp_version"
+    mkdir -p "$link_dir"
+
+    if [ -f "$output_dir/openshift-install" ]; then
+        ln -sf "$output_dir/openshift-install" "$link_dir/openshift-install"
+        export OPENSHIFT_INSTALLER="$link_dir/openshift-install"
+        echo "OCP installer already exists in $output_dir, skipping download."
+        return 0
+    fi
+
+    local installer_url
+    installer_url=$(get_ocp_download_url "$version_string")
+    if [[ $? -ne 0 ]] || [[ -z "$installer_url" ]]; then
+        echo "Error: Failed to get installer URL for OCP version $ocp_version" >&2
+        return 1
+    fi
+
+    cd "$output_dir" || {
+        echo "Error: Failed to change to output directory: $output_dir" >&2
+        return 1
+    }
+
+    echo "Downloading OCP installer from: $installer_url"
+    curl -sS -L -o openshift-install.tar.gz "$installer_url"
+    if [[ $? -ne 0 ]]; then
+        echo "Error: Failed to download OCP installer" >&2
+        echo "Note: Ensure you have network access to mirror.openshift.com" >&2
+        return 1
+    fi
+
+    echo "Unpacking OCP installer"
+    tar xfz openshift-install.tar.gz
+    if [[ $? -ne 0 ]]; then
+        echo "Error: Failed to unpack OCP installer" >&2
+        return 1
+    fi
+
+    rm openshift-install.tar.gz
+    rm -f README.md
+
+    ln -sf "$output_dir/openshift-install" "$link_dir/openshift-install"
+    export OPENSHIFT_INSTALLER="$link_dir/openshift-install"
+
+    echo "OCP installer successfully downloaded and extracted to: $output_dir"
+
+    # Display version information
+    "$link_dir/openshift-install" version
+
+    return 0
+}
+
+# Displays usage information
+usage() {
+    echo "Usage: $0 --version <ocp-version>"
+    echo ""
+    echo "Required Parameters:"
+    echo "  --version <ocp-version>      OCP version to download (e.g., 4.16)"
+    echo ""
+    echo "Options:"
+    echo "  -h, --help                   Show this help message"
+    echo ""
+    echo "Example:"
+    echo "  $0 --version 4.16"
+    echo ""
+    echo "Supported Versions:"
+    echo "  4.16 - Stable release (recommended)"
+    echo "  4.17 - Future stable release"
+    exit 1
+}
+
+# Initialize variables
+OCP_VERSION=""
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --version)
+            OCP_VERSION="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# Validate required parameters
+if [[ -z "$OCP_VERSION" ]]; then
+    echo "Error: --version parameter is required"
+    usage
+fi
+
+# Download the OCP installer
+download_ocp_installer "$OCP_VERSION"
+exit $?

--- a/download-ocp-installer.sh
+++ b/download-ocp-installer.sh
@@ -144,10 +144,6 @@ usage() {
     echo ""
     echo "Example:"
     echo "  $0 --version 4.16"
-    echo ""
-    echo "Supported Versions:"
-    echo "  4.16 - Stable release (recommended)"
-    echo "  4.17 - Future stable release"
     exit 1
 }
 

--- a/install-cluster.sh
+++ b/install-cluster.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Script to install OKD cluster
+# Script to install OCP cluster
 # Usage: ./install-cluster.sh [--cluster <cluster-name>]
 
 # Get the directory where this script is located
@@ -82,14 +82,14 @@ extract_console_password() {
 
 # Function to display usage
 usage() {
-    echo    "Usage: $0 [--cluster <cluster-name>] [--okdVersion <okd-version>] [--region <aws-region>] [--computeNodes <count>] [--controlPlaneNodes <count>] [--baseDomain <domain>] [--log-level <level>] [--force]"
+    echo    "Usage: $0 [--cluster <cluster-name>] [--ocpVersion <ocp-version>] [--region <aws-region>] [--computeNodes <count>] [--controlPlaneNodes <count>] [--baseDomain <domain>] [--log-level <level>] [--force]"
     echo    ""
     echo    "Optional Parameters:"
     echo    "  --cluster <cluster-name>     Name of the cluster to install (default: $USER)"
     echo    "                               Must contain only letters and numbers"
     echo    ""
     echo    "Optional Parameters:"
-    echo    "  --okdVersion <version>       OKD version to install (default: 4.19)"
+    echo    "  --ocpVersion <version>       OCP version to install (default: 4.16)"
     echo    "  --region <aws-region>        AWS region to deploy to (default: us-east-1)"
     echo    "  --computeNodes <count>       Number of compute/worker nodes (default: 3)"
     echo    "  --controlPlaneNodes <count>  Number of control plane/master nodes (default: 3)"
@@ -102,7 +102,7 @@ usage() {
 
 # Initialize variables
 CLUSTER_NAME="$USER"
-OKD_VERSION="4.19"
+OCP_VERSION="4.16"
 REGION="us-east-1"
 COMPUTE_NODES="3"
 CONTROL_PLANE_NODES="3"
@@ -117,8 +117,8 @@ while [[ $# -gt 0 ]]; do
             CLUSTER_NAME="$2"
             shift 2
             ;;
-        --okdVersion)
-            OKD_VERSION="$2"
+        --ocpVersion)
+            OCP_VERSION="$2"
             shift 2
             ;;
         --region)
@@ -193,7 +193,7 @@ echo "Using AWS region: $REGION"
 # Validate required environment variables
 validate_env_vars
 
-echo "Installing OKD cluster with name: $CLUSTER_NAME (OKD version: $OKD_VERSION)"
+echo "Installing OCP cluster with name: $CLUSTER_NAME (OCP version: $OCP_VERSION)"
 echo "Cluster configuration: $CONTROL_PLANE_NODES control plane nodes, $COMPUTE_NODES compute nodes"
 echo "Using base domain: $BASE_DOMAIN"
 CLUSTER_DIR=$CLUSTERS_DIR/$CLUSTER_NAME
@@ -215,16 +215,16 @@ if [[ -d "$CLUSTER_DIR" ]]; then
     fi
 fi
 
-# Create a work directory for installing the OKD cluster
+# Create a work directory for installing the OCP cluster
 mkdir -p $CLUSTER_DIR
 cd $CLUSTER_DIR || exit 1
 
-"$BASE_DIR/download-okd-installer.sh" --version "$OKD_VERSION"
+"$BASE_DIR/download-ocp-installer.sh" --version "$OCP_VERSION"
 if [[ $? -ne 0 ]]; then
-    echo "Error: Failed to download openshift-install for OKD version $OKD_VERSION."
+    echo "Error: Failed to download openshift-install for OCP version $OCP_VERSION."
     exit 1
 fi
-OPENSHIFT_INSTALLER="$BIN_DIR/$OKD_VERSION/openshift-install"
+OPENSHIFT_INSTALLER="$BIN_DIR/$OCP_VERSION/openshift-install"
 
 # Create the install-config.yaml file (from template)
 echo "Creating install-config.yaml from template with environment variable substitution"
@@ -233,9 +233,9 @@ export REGION
 export COMPUTE_NODES
 export CONTROL_PLANE_NODES
 export BASE_DOMAIN
-envsubst < $BASE_DIR/templates/okd/$OKD_VERSION/install-config.yaml > $CLUSTER_DIR/install-config.yaml
+envsubst < $BASE_DIR/templates/ocp/$OCP_VERSION/install-config.yaml > $CLUSTER_DIR/install-config.yaml
 
-echo -n "$OKD_VERSION" > "$CLUSTER_DIR/version"
+echo -n "$OCP_VERSION" > "$CLUSTER_DIR/version"
 
 unset SSH_AUTH_SOCK
 

--- a/install-cluster.sh
+++ b/install-cluster.sh
@@ -89,7 +89,7 @@ usage() {
     echo    "                               Must contain only letters and numbers"
     echo    ""
     echo    "Optional Parameters:"
-    echo    "  --ocpVersion <version>       OCP version to install (default: 4.16)"
+    echo    "  --ocpVersion <version>       OCP version to install (default: 4.19)"
     echo    "  --region <aws-region>        AWS region to deploy to (default: us-east-1)"
     echo    "  --computeNodes <count>       Number of compute/worker nodes (default: 3)"
     echo    "  --controlPlaneNodes <count>  Number of control plane/master nodes (default: 3)"
@@ -102,7 +102,7 @@ usage() {
 
 # Initialize variables
 CLUSTER_NAME="$USER"
-OCP_VERSION="4.16"
+OCP_VERSION="4.19"
 REGION="us-east-1"
 COMPUTE_NODES="3"
 CONTROL_PLANE_NODES="3"

--- a/templates/ocp/4.16/install-config.yaml
+++ b/templates/ocp/4.16/install-config.yaml
@@ -3,6 +3,8 @@ metadata:
   name: $CLUSTER_NAME
 baseDomain: $BASE_DOMAIN
 controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
   name: master
   replicas: $CONTROL_PLANE_NODES
   platform:

--- a/templates/ocp/4.16/install-config.yaml
+++ b/templates/ocp/4.16/install-config.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+metadata:
+  name: $CLUSTER_NAME
+baseDomain: $BASE_DOMAIN
+controlPlane:
+  name: master
+  replicas: $CONTROL_PLANE_NODES
+  platform:
+    aws:
+      type: m5.xlarge
+      zones:
+        - us-east-1a
+compute:
+  - name: worker
+    replicas: $COMPUTE_NODES
+    platform:
+      aws:
+        type: m5.xlarge
+        zones:
+          - us-east-1a
+platform:
+  aws:
+    region: $REGION
+    userTags:
+      apicurio/Environment: TEST
+      apicurio/ForCleanup: "true"
+      apicurio/FromOcpInstaller: "true"
+      apicurio/cluster: $CLUSTER_NAME
+      app-code: SRQE-001
+      service-phase: dev
+      cost-center: 704
+fips: false
+pullSecret: |
+  $OPENSHIFT_PULL_SECRET
+sshKey: |
+  $SSH_PUBLIC_KEY

--- a/templates/ocp/4.19/install-config.yaml
+++ b/templates/ocp/4.19/install-config.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+metadata:
+  name: $CLUSTER_NAME
+baseDomain: $BASE_DOMAIN
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  replicas: $CONTROL_PLANE_NODES
+  platform:
+    aws:
+      type: m5.xlarge
+      zones:
+        - us-east-1a
+compute:
+  - name: worker
+    replicas: $COMPUTE_NODES
+    platform:
+      aws:
+        type: m5.xlarge
+        zones:
+          - us-east-1a
+platform:
+  aws:
+    region: $REGION
+    userTags:
+      apicurio/Environment: TEST
+      apicurio/ForCleanup: "true"
+      apicurio/FromOcpInstaller: "true"
+      apicurio/cluster: $CLUSTER_NAME
+      app-code: SRQE-001
+      service-phase: dev
+      cost-center: 704
+fips: false
+pullSecret: |
+  $OPENSHIFT_PULL_SECRET
+sshKey: |
+  $SSH_PUBLIC_KEY

--- a/templates/registry-operator/3.1.1/apicurio-registry-operator.yaml
+++ b/templates/registry-operator/3.1.1/apicurio-registry-operator.yaml
@@ -1,0 +1,6875 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app: apicurio-registry-operator
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: apicurio-registry-operator
+    app.kubernetes.io/name: apicurio-registry-operator
+    app.kubernetes.io/part-of: apicurio-registry
+    app.kubernetes.io/version: 3.1.1
+  name: apicurioregistries3.registry.apicur.io
+spec:
+  group: registry.apicur.io
+  names:
+    kind: ApicurioRegistry3
+    plural: apicurioregistries3
+    shortNames:
+    - registry3
+    singular: apicurioregistry3
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            properties:
+              app:
+                description: Configure Apicurio Registry backend (app) component.
+                properties:
+                  auth:
+                    description: |
+                      Configure authentication and authorization of Apicurio Registry.
+                    properties:
+                      anonymousReadsEnabled:
+                        description: To allow anonymous users, such as REST API calls
+                          with no authentication credentials, to make read-only calls
+                          to the REST API, set the following option to true.
+                        type: boolean
+                      appClientId:
+                        description: |-
+                          Apicurio Registry backend clientId used for OIDC authentication.
+                          In Identity providers like Keycloak, this is the client id used for the Quarkus backend application
+                        type: string
+                      authServerUrl:
+                        description: URL of the identity server.
+                        type: string
+                      authz:
+                        description: Authorization configuration.
+                        properties:
+                          adminOverride:
+                            description: Admin override configuration
+                            properties:
+                              claimName:
+                                description: The name of a JWT token claim to use
+                                  for determining admin-override.
+                                type: string
+                              claimValue:
+                                description: The value that the JWT token claim indicated
+                                  by the CLAIM variable must be for the user to be
+                                  granted admin-override.
+                                type: string
+                              enabled:
+                                description: Auth admin override enabled.
+                                type: boolean
+                              from:
+                                description: Where to look for admin-override information.
+                                  Only token is currently supported.
+                                type: string
+                              role:
+                                description: The name of the role that indicates a
+                                  user is an admin.
+                                type: string
+                              type:
+                                description: The type of information used to determine
+                                  if a user is an admin. Values depend on the value
+                                  of the FROM variable, for example, role or claim
+                                  when FROM is token.
+                                type: string
+                            type: object
+                          enabled:
+                            description: Enabled role-based authorization.
+                            type: boolean
+                          groupAccessEnabled:
+                            description: When owner-only authorization and group owner-only
+                              authorization are both enabled, only the user who created
+                              an artifact group has write access to that artifact
+                              group, for example, to add or remove artifacts in that
+                              group.
+                            type: boolean
+                          ownerOnlyEnabled:
+                            description: When owner-only authorization is enabled,
+                              only the user who created an artifact can modify or
+                              delete that artifact.
+                            type: boolean
+                          readAccessEnabled:
+                            description: When the authenticated read access option
+                              is enabled, Apicurio Registry grants at least read-only
+                              access to requests from any authenticated user in the
+                              same organization, regardless of their user role.
+                            type: boolean
+                          roles:
+                            description: Configure authorization role source and role
+                              names.
+                            properties:
+                              admin:
+                                description: The name of the role that indicates a
+                                  user is an admin.
+                                type: string
+                              developer:
+                                description: The name of the role that indicates a
+                                  user is a developer.
+                                type: string
+                              readOnly:
+                                description: The name of the role that indicates a
+                                  user has read-only access.
+                                type: string
+                              source:
+                                description: When set to token, user roles are taken
+                                  from the authentication token.
+                                type: string
+                            type: object
+                        type: object
+                      basicAuth:
+                        description: Client credentials basic auth configuration.
+                        properties:
+                          cacheExpiration:
+                            description: |
+                              Client credentials token expiration time. This value is a string representing a duration:
+
+                              | Abbreviation          | Time Unit    |
+                              |-----------------------|--------------|
+                              | ns, nano, nanos       | Nanosecond   |
+                              | us, µs, micro, micros | Microseconds |
+                              | ms, milli, millis     | Millisecond  |
+                              | s, sec, secs          | Second       |
+                              | m, min, mins          | Minute       |
+                              | h, hr, hour, hours    | Hour         |
+                              | d, day, days          | Day          |
+                              | w, wk, week, weeks    | Week         |
+
+                              Example: "1min1s"
+                            type: string
+                          enabled:
+                            description: Enabled client credentials.
+                            type: boolean
+                        type: object
+                      enabled:
+                        description: |-
+                          Enable Apicurio Registry Authentication.
+                          In Identity providers like Keycloak, this is the client id used for the Quarkus backend application
+                        type: boolean
+                      logoutUrl:
+                        description: Apicurio Registry UI redirect URI used for redirection
+                          after logout.
+                        type: string
+                      redirectUri:
+                        description: Apicurio Registry UI redirect URI used for redirection
+                          after successful authentication.
+                        type: string
+                      tls:
+                        description: |-
+                          OIDC TLS configuration.
+                          When custom certificates are used, this is the field to be used to configure the trustore
+                        properties:
+                          tlsVerificationType:
+                            description: Verify the identity server certificate.
+                            type: string
+                          truststorePasswordSecretRef:
+                            description: Name of a Secret that contains the TLS truststore
+                              password. Key `ca.password` is assumed by default.
+                            properties:
+                              key:
+                                description: Name of the key in the referenced Secret
+                                  that contain the target data. This field might be
+                                  optional if a default value has been defined.
+                                type: string
+                              name:
+                                description: Name of a Secret that is being referenced.
+                                type: string
+                            type: object
+                          truststoreSecretRef:
+                            description: Name of a Secret that contains the TLS truststore
+                              (in PKCS12 format). Key `ca.p12` is assumed by default.
+                            properties:
+                              key:
+                                description: Name of the key in the referenced Secret
+                                  that contain the target data. This field might be
+                                  optional if a default value has been defined.
+                                type: string
+                              name:
+                                description: Name of a Secret that is being referenced.
+                                type: string
+                            type: object
+                        type: object
+                      uiClientId:
+                        description: |-
+                          Apicurio Registry UI clientId used for OIDC authentication.
+                          In Identity providers like Keycloak, this is the client id used for the frontend React application
+                        type: string
+                    type: object
+                  env:
+                    description: Configure a list of environment variables that will
+                      be passed to this components' container.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                        valueFrom:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              type: object
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              type: object
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                          type: object
+                      type: object
+                    type: array
+                  features:
+                    description: |
+                      Configure features of the Apicurio Registry backend (app).
+                    properties:
+                      resourceDeleteEnabled:
+                        description: |-
+                          Apicurio Registry backend 'allow deletes' feature.
+                          If the value is true, the application will be configured to allow Groups, Artifacts, and
+                          Artifact Versions to be deleted.  By default, resources in Registry are immutable and so
+                          cannot be deleted. Registry can be configured to allow deleting of these resources at a
+                          granular level (e.g. only allow deleting artifact versions) using ENV variables.  This
+                          option enables deletes for all three resource types.
+                        type: boolean
+                    type: object
+                  host:
+                    description: 'DEPRECATED: Use the `(component).ingress.host` field
+                      instead. The operator will attempt to update the field automatically.'
+                    type: string
+                  ingress:
+                    description: Configure Ingress for the component.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Additional annotations for the operator-managed
+                          Ingress.
+                        type: object
+                      enabled:
+                        description: |
+                          Whether an Ingress should be managed by the operator.  Defaults to 'true'.
+
+                          Set this to 'false' if you want to create your own custom Ingress.
+                        type: boolean
+                      host:
+                        description: |-
+                          Configure hostname of the operator-managed Ingress. If the value is empty, the operator will not create an Ingress resource for the component.
+
+                          IMPORTANT: If the Ingress already exists and the value becomes empty, the Ingress will be deleted.
+                        type: string
+                      ingressClassName:
+                        description: |-
+                          Name of an IngressClass cluster resource. Ingress controller implementations use this field to know whether they should be serving this Ingress resource, by a transitive connection (controller -> IngressClass -> Ingress resource).
+
+                          See https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class.
+                        type: string
+                    type: object
+                  kafkasql:
+                    description: |-
+                      DEPRECATED: Use the `app.storage.type` and `app.storage.kafkasql` fields instead.
+                       The operator will attempt to update the fields automatically.
+                    properties:
+                      bootstrapServers:
+                        description: 'DEPRECATED: Use the `app.storage.kafkasql.bootstrapServers`
+                          field instead. The operator will attempt to update the field
+                          automatically.'
+                        type: string
+                    type: object
+                  networkPolicy:
+                    description: |2
+                              Configuration of a NetworkPolicy for the component.
+                    properties:
+                      enabled:
+                        description: |
+                          Whether a NetworkPolicy should be managed by the operator.  Defaults to 'true'.
+
+                          Set this to 'false' if you want to create your own custom NetworkPolicy.
+                        type: boolean
+                    type: object
+                  podDisruptionBudget:
+                    description: |
+                      Configuration of a PodDisruptionBudget for the component.
+                    properties:
+                      enabled:
+                        description: |
+                          Whether a PodDisruptionBudget should be managed by the operator.  Defaults to 'true'.
+
+                          Set this to 'false' if you want to create your own custom PodDisruptionBudget.
+                        type: boolean
+                    type: object
+                  podTemplateSpec:
+                    description: |-
+                      `PodTemplateSpec` describes the data a pod should have when created from a template.
+
+                      This template is used by the operator to create the components' Deployment. The operator first extends the template
+                      with default values if required, and then applies additional configuration
+                      based on the other contents of `ApicurioRegistry3` CR.
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          creationTimestamp:
+                            type: string
+                          deletionGracePeriodSeconds:
+                            type: integer
+                          deletionTimestamp:
+                            type: string
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          generateName:
+                            type: string
+                          generation:
+                            type: integer
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          managedFields:
+                            items:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldsType:
+                                  type: string
+                                fieldsV1:
+                                  type: object
+                                manager:
+                                  type: string
+                                operation:
+                                  type: string
+                                subresource:
+                                  type: string
+                                time:
+                                  type: string
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          ownerReferences:
+                            items:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                blockOwnerDeletion:
+                                  type: boolean
+                                controller:
+                                  type: boolean
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                uid:
+                                  type: string
+                              type: object
+                            type: array
+                          resourceVersion:
+                            type: string
+                          selfLink:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      spec:
+                        properties:
+                          activeDeadlineSeconds:
+                            type: integer
+                          affinity:
+                            properties:
+                              nodeAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        preference:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                            matchFields:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                          type: object
+                                        weight:
+                                          type: integer
+                                      type: object
+                                    type: array
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    properties:
+                                      nodeSelectorTerms:
+                                        items:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                            matchFields:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              podAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        podAffinityTerm:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              type: string
+                                          type: object
+                                        weight:
+                                          type: integer
+                                      type: object
+                                    type: array
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                              podAntiAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        podAffinityTerm:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              type: string
+                                          type: object
+                                        weight:
+                                          type: integer
+                                      type: object
+                                    type: array
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          automountServiceAccountToken:
+                            type: boolean
+                          containers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            type: object
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            type: object
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: integer
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: integer
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        type: string
+                                    type: object
+                                  type: array
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  items:
+                                    properties:
+                                      resourceName:
+                                        type: string
+                                      restartPolicy:
+                                        type: string
+                                    type: object
+                                  type: array
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  type: string
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        hostProcess:
+                                          type: boolean
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        type: string
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    type: object
+                                  type: array
+                                workingDir:
+                                  type: string
+                              type: object
+                            type: array
+                          dnsConfig:
+                            properties:
+                              nameservers:
+                                items:
+                                  type: string
+                                type: array
+                              options:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                              searches:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          dnsPolicy:
+                            type: string
+                          enableServiceLinks:
+                            type: boolean
+                          ephemeralContainers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            type: object
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            type: object
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: integer
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: integer
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        type: string
+                                    type: object
+                                  type: array
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  items:
+                                    properties:
+                                      resourceName:
+                                        type: string
+                                      restartPolicy:
+                                        type: string
+                                    type: object
+                                  type: array
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  type: string
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        hostProcess:
+                                          type: boolean
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                targetContainerName:
+                                  type: string
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        type: string
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    type: object
+                                  type: array
+                                workingDir:
+                                  type: string
+                              type: object
+                            type: array
+                          hostAliases:
+                            items:
+                              properties:
+                                hostnames:
+                                  items:
+                                    type: string
+                                  type: array
+                                ip:
+                                  type: string
+                              type: object
+                            type: array
+                          hostIPC:
+                            type: boolean
+                          hostNetwork:
+                            type: boolean
+                          hostPID:
+                            type: boolean
+                          hostUsers:
+                            type: boolean
+                          hostname:
+                            type: string
+                          imagePullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            type: array
+                          initContainers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            type: object
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            type: object
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: integer
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: integer
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        type: string
+                                    type: object
+                                  type: array
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  items:
+                                    properties:
+                                      resourceName:
+                                        type: string
+                                      restartPolicy:
+                                        type: string
+                                    type: object
+                                  type: array
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  type: string
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        hostProcess:
+                                          type: boolean
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        type: string
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    type: object
+                                  type: array
+                                workingDir:
+                                  type: string
+                              type: object
+                            type: array
+                          nodeName:
+                            type: string
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          os:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          overhead:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          preemptionPolicy:
+                            type: string
+                          priority:
+                            type: integer
+                          priorityClassName:
+                            type: string
+                          readinessGates:
+                            items:
+                              properties:
+                                conditionType:
+                                  type: string
+                              type: object
+                            type: array
+                          resourceClaims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                resourceClaimName:
+                                  type: string
+                                resourceClaimTemplateName:
+                                  type: string
+                              type: object
+                            type: array
+                          resources:
+                            properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    request:
+                                      type: string
+                                  type: object
+                                type: array
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          restartPolicy:
+                            type: string
+                          runtimeClassName:
+                            type: string
+                          schedulerName:
+                            type: string
+                          schedulingGates:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            type: array
+                          securityContext:
+                            properties:
+                              appArmorProfile:
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
+                                type: object
+                              fsGroup:
+                                type: integer
+                              fsGroupChangePolicy:
+                                type: string
+                              runAsGroup:
+                                type: integer
+                              runAsNonRoot:
+                                type: boolean
+                              runAsUser:
+                                type: integer
+                              seLinuxChangePolicy:
+                                type: string
+                              seLinuxOptions:
+                                properties:
+                                  level:
+                                    type: string
+                                  role:
+                                    type: string
+                                  type:
+                                    type: string
+                                  user:
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
+                                type: object
+                              supplementalGroups:
+                                items:
+                                  type: integer
+                                type: array
+                              supplementalGroupsPolicy:
+                                type: string
+                              sysctls:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  hostProcess:
+                                    type: boolean
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                            type: object
+                          serviceAccount:
+                            type: string
+                          serviceAccountName:
+                            type: string
+                          setHostnameAsFQDN:
+                            type: boolean
+                          shareProcessNamespace:
+                            type: boolean
+                          subdomain:
+                            type: string
+                          terminationGracePeriodSeconds:
+                            type: integer
+                          tolerations:
+                            items:
+                              properties:
+                                effect:
+                                  type: string
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                tolerationSeconds:
+                                  type: integer
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          topologySpreadConstraints:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                matchLabelKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                maxSkew:
+                                  type: integer
+                                minDomains:
+                                  type: integer
+                                nodeAffinityPolicy:
+                                  type: string
+                                nodeTaintsPolicy:
+                                  type: string
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                              type: object
+                            type: array
+                          volumes:
+                            items:
+                              properties:
+                                awsElasticBlockStore:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    partition:
+                                      type: integer
+                                    readOnly:
+                                      type: boolean
+                                    volumeID:
+                                      type: string
+                                  type: object
+                                azureDisk:
+                                  properties:
+                                    cachingMode:
+                                      type: string
+                                    diskName:
+                                      type: string
+                                    diskURI:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  type: object
+                                azureFile:
+                                  properties:
+                                    readOnly:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                    shareName:
+                                      type: string
+                                  type: object
+                                cephfs:
+                                  properties:
+                                    monitors:
+                                      items:
+                                        type: string
+                                      type: array
+                                    path:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretFile:
+                                      type: string
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    user:
+                                      type: string
+                                  type: object
+                                cinder:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    volumeID:
+                                      type: string
+                                  type: object
+                                configMap:
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                csi:
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    nodePublishSecretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    readOnly:
+                                      type: boolean
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                downwardAPI:
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            type: object
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                                emptyDir:
+                                  properties:
+                                    medium:
+                                      type: string
+                                    sizeLimit:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                ephemeral:
+                                  properties:
+                                    volumeClaimTemplate:
+                                      properties:
+                                        metadata:
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            creationTimestamp:
+                                              type: string
+                                            deletionGracePeriodSeconds:
+                                              type: integer
+                                            deletionTimestamp:
+                                              type: string
+                                            finalizers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            generateName:
+                                              type: string
+                                            generation:
+                                              type: integer
+                                            labels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            managedFields:
+                                              items:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldsType:
+                                                    type: string
+                                                  fieldsV1:
+                                                    type: object
+                                                  manager:
+                                                    type: string
+                                                  operation:
+                                                    type: string
+                                                  subresource:
+                                                    type: string
+                                                  time:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            ownerReferences:
+                                              items:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  blockOwnerDeletion:
+                                                    type: boolean
+                                                  controller:
+                                                    type: boolean
+                                                  kind:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  uid:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            resourceVersion:
+                                              type: string
+                                            selfLink:
+                                              type: string
+                                            uid:
+                                              type: string
+                                          type: object
+                                        spec:
+                                          properties:
+                                            accessModes:
+                                              items:
+                                                type: string
+                                              type: array
+                                            dataSource:
+                                              properties:
+                                                apiGroup:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              type: object
+                                            dataSourceRef:
+                                              properties:
+                                                apiGroup:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              type: object
+                                            resources:
+                                              properties:
+                                                limits:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  type: object
+                                                requests:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  type: object
+                                              type: object
+                                            selector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            storageClassName:
+                                              type: string
+                                            volumeAttributesClassName:
+                                              type: string
+                                            volumeMode:
+                                              type: string
+                                            volumeName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                  type: object
+                                fc:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    lun:
+                                      type: integer
+                                    readOnly:
+                                      type: boolean
+                                    targetWWNs:
+                                      items:
+                                        type: string
+                                      type: array
+                                    wwids:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                flexVolume:
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    options:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                flocker:
+                                  properties:
+                                    datasetName:
+                                      type: string
+                                    datasetUUID:
+                                      type: string
+                                  type: object
+                                gcePersistentDisk:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    partition:
+                                      type: integer
+                                    pdName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  type: object
+                                gitRepo:
+                                  properties:
+                                    directory:
+                                      type: string
+                                    repository:
+                                      type: string
+                                    revision:
+                                      type: string
+                                  type: object
+                                glusterfs:
+                                  properties:
+                                    endpoints:
+                                      type: string
+                                    path:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  type: object
+                                hostPath:
+                                  properties:
+                                    path:
+                                      type: string
+                                    type:
+                                      type: string
+                                  type: object
+                                image:
+                                  properties:
+                                    pullPolicy:
+                                      type: string
+                                    reference:
+                                      type: string
+                                  type: object
+                                iscsi:
+                                  properties:
+                                    chapAuthDiscovery:
+                                      type: boolean
+                                    chapAuthSession:
+                                      type: boolean
+                                    fsType:
+                                      type: string
+                                    initiatorName:
+                                      type: string
+                                    iqn:
+                                      type: string
+                                    iscsiInterface:
+                                      type: string
+                                    lun:
+                                      type: integer
+                                    portals:
+                                      items:
+                                        type: string
+                                      type: array
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    targetPortal:
+                                      type: string
+                                  type: object
+                                name:
+                                  type: string
+                                nfs:
+                                  properties:
+                                    path:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    server:
+                                      type: string
+                                  type: object
+                                persistentVolumeClaim:
+                                  properties:
+                                    claimName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  type: object
+                                photonPersistentDisk:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    pdID:
+                                      type: string
+                                  type: object
+                                portworxVolume:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    volumeID:
+                                      type: string
+                                  type: object
+                                projected:
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    sources:
+                                      items:
+                                        properties:
+                                          clusterTrustBundle:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                              path:
+                                                type: string
+                                              signerName:
+                                                type: string
+                                            type: object
+                                          configMap:
+                                            properties:
+                                              items:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    mode:
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                          downwardAPI:
+                                            properties:
+                                              items:
+                                                items:
+                                                  properties:
+                                                    fieldRef:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldPath:
+                                                          type: string
+                                                      type: object
+                                                    mode:
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                    resourceFieldRef:
+                                                      properties:
+                                                        containerName:
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          secret:
+                                            properties:
+                                              items:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    mode:
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                          serviceAccountToken:
+                                            properties:
+                                              audience:
+                                                type: string
+                                              expirationSeconds:
+                                                type: integer
+                                              path:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                                quobyte:
+                                  properties:
+                                    group:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    registry:
+                                      type: string
+                                    tenant:
+                                      type: string
+                                    user:
+                                      type: string
+                                    volume:
+                                      type: string
+                                  type: object
+                                rbd:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    image:
+                                      type: string
+                                    keyring:
+                                      type: string
+                                    monitors:
+                                      items:
+                                        type: string
+                                      type: array
+                                    pool:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    user:
+                                      type: string
+                                  type: object
+                                scaleIO:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    gateway:
+                                      type: string
+                                    protectionDomain:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    sslEnabled:
+                                      type: boolean
+                                    storageMode:
+                                      type: string
+                                    storagePool:
+                                      type: string
+                                    system:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  type: object
+                                secret:
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    optional:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                  type: object
+                                storageos:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    volumeName:
+                                      type: string
+                                    volumeNamespace:
+                                      type: string
+                                  type: object
+                                vsphereVolume:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    storagePolicyID:
+                                      type: string
+                                    storagePolicyName:
+                                      type: string
+                                    volumePath:
+                                      type: string
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  replicas:
+                    description: Number of replicas for the component
+                    type: integer
+                  sql:
+                    description: |-
+                      DEPRECATED: Use the `app.storage.type` and `app.storage.sql` fields instead.
+                      The operator will attempt to update the fields automatically.
+                    properties:
+                      dataSource:
+                        description: 'DEPRECATED: Use the `app.storage.sql.dataSource`
+                          field instead. The operator will attempt to update the field
+                          automatically.'
+                        properties:
+                          password:
+                            description: 'DEPRECATED: Use the `app.storage.sql.dataSource.password`
+                              field instead. The operator will attempt to update the
+                              field automatically.'
+                            type: string
+                          url:
+                            description: 'DEPRECATED: Use the `app.storage.sql.dataSource.url`
+                              field instead. The operator will attempt to update the
+                              field automatically.'
+                            type: string
+                          username:
+                            description: 'DEPRECATED: Use the `app.storage.sql.dataSource.username`
+                              field instead. The operator will attempt to update the
+                              field automatically.'
+                            type: string
+                        type: object
+                    type: object
+                  storage:
+                    description: |
+                      Configure storage for Apicurio Registry backend (app).
+                    properties:
+                      kafkasql:
+                        description: Configure KafkaSQL storage type.
+                        properties:
+                          auth:
+                            description: Configure KafkaSQL storage authentication.
+                            properties:
+                              clientIdRef:
+                                description: The clientId used to authenticate to
+                                  Kafka.
+                                properties:
+                                  key:
+                                    description: Name of the key in the referenced
+                                      Secret that contain the target data. This field
+                                      might be optional if a default value has been
+                                      defined.
+                                    type: string
+                                  name:
+                                    description: Name of a Secret that is being referenced.
+                                    type: string
+                                type: object
+                              clientSecretRef:
+                                description: The client secret used to authenticate
+                                  to Kafka.
+                                properties:
+                                  key:
+                                    description: Name of the key in the referenced
+                                      Secret that contain the target data. This field
+                                      might be optional if a default value has been
+                                      defined.
+                                    type: string
+                                  name:
+                                    description: Name of a Secret that is being referenced.
+                                    type: string
+                                type: object
+                              enabled:
+                                description: Enables SASL OAuth authentication for
+                                  Apicurio Registry storage in Kafka. You must set
+                                  this variable to true for the other variables to
+                                  have effect.
+                                type: boolean
+                              loginHandlerClass:
+                                description: The login class to be used for login.
+                                type: string
+                              mechanism:
+                                description: The mechanism used to authenticate to
+                                  Kafka.
+                                type: string
+                              tokenEndpoint:
+                                description: The URL of the OAuth identity server.
+                                type: string
+                            type: object
+                          bootstrapServers:
+                            description: |-
+                              Configure Kafka bootstrap servers.
+
+                              Required if `app.storage.type` is `kafkasql`.
+                            type: string
+                          tls:
+                            description: Configure KafkaSQL storage when the access
+                              to the Kafka cluster is secured using TLS.
+                            properties:
+                              keystorePasswordSecretRef:
+                                description: |-
+                                  Reference to the Secret that contains the TLS keystore password.
+                                  Key `user.password` is assumed by default.
+                                properties:
+                                  key:
+                                    description: Name of the key in the referenced
+                                      Secret that contain the target data. This field
+                                      might be optional if a default value has been
+                                      defined.
+                                    type: string
+                                  name:
+                                    description: Name of a Secret that is being referenced.
+                                    type: string
+                                type: object
+                              keystoreSecretRef:
+                                description: Reference to the Secret that contains
+                                  the TLS keystore (in PKCS12 format). Key `user.p12`
+                                  is assumed by default.
+                                properties:
+                                  key:
+                                    description: Name of the key in the referenced
+                                      Secret that contain the target data. This field
+                                      might be optional if a default value has been
+                                      defined.
+                                    type: string
+                                  name:
+                                    description: Name of a Secret that is being referenced.
+                                    type: string
+                                type: object
+                              truststorePasswordSecretRef:
+                                description: Name of a Secret that contains the TLS
+                                  truststore password. Key `ca.password` is assumed
+                                  by default.
+                                properties:
+                                  key:
+                                    description: Name of the key in the referenced
+                                      Secret that contain the target data. This field
+                                      might be optional if a default value has been
+                                      defined.
+                                    type: string
+                                  name:
+                                    description: Name of a Secret that is being referenced.
+                                    type: string
+                                type: object
+                              truststoreSecretRef:
+                                description: Name of a Secret that contains the TLS
+                                  truststore (in PKCS12 format). Key `ca.p12` is assumed
+                                  by default.
+                                properties:
+                                  key:
+                                    description: Name of the key in the referenced
+                                      Secret that contain the target data. This field
+                                      might be optional if a default value has been
+                                      defined.
+                                    type: string
+                                  name:
+                                    description: Name of a Secret that is being referenced.
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      sql:
+                        description: Configure SQL storage types.
+                        properties:
+                          dataSource:
+                            description: Configure SQL data source.
+                            properties:
+                              password:
+                                description: |-
+                                  Configure SQL data source password.
+
+                                  References name of a Secret that contains the password. Key `password` is assumed by default.
+                                properties:
+                                  key:
+                                    description: Name of the key in the referenced
+                                      Secret that contain the target data. This field
+                                      might be optional if a default value has been
+                                      defined.
+                                    type: string
+                                  name:
+                                    description: Name of a Secret that is being referenced.
+                                    type: string
+                                type: object
+                              url:
+                                description: |-
+                                  Configure SQL data source URL.
+
+                                  Example: `jdbc:postgresql://example-postgresql-database:5432/apicurio`.
+                                type: string
+                              username:
+                                description: Configure SQL data source username.
+                                type: string
+                            type: object
+                        type: object
+                      type:
+                        description: |-
+                          Configure type of storage that Apicurio Registry backend (app) will use:
+
+                            * <empty> - in-memory storage.
+                            * `postgresql` - Postgresql storage type, must be further configured using the `app.storage.sql` field.
+                            * `kafkasql` - KafkaSQL storage type, must be further configured using the `app.storage.kafkasql` field.
+
+                          IMPORTANT: Defaults to the in-memory storage, which is not suitable for production.
+                        enum:
+                        - kafkasql
+                        - postgresql
+                        type: string
+                    type: object
+                  tls:
+                    description: |
+                      Configure tls of Apicurio Registry.
+                    properties:
+                      insecureRequests:
+                        description: |
+                          If insecure (i.e. http rather than https) requests are allowed. If this is `enabled` then http works as normal. `redirect` will still open the http port, but all requests will be redirected to the HTTPS port. `disabled` will prevent the HTTP port from opening at all.
+                        enum:
+                        - disabled
+                        - enabled
+                        - redirect
+                        type: string
+                      keystorePasswordSecretRef:
+                        description: Name of a Secret that contains the TLS keystore
+                          password. Key `ca.password` is assumed by default.
+                        properties:
+                          key:
+                            description: Name of the key in the referenced Secret
+                              that contain the target data. This field might be optional
+                              if a default value has been defined.
+                            type: string
+                          name:
+                            description: Name of a Secret that is being referenced.
+                            type: string
+                        type: object
+                      keystoreSecretRef:
+                        description: Name of a Secret that contains the TLS keystore
+                          (in PKCS12 format). Key `ca.p12` is assumed by default.
+                        properties:
+                          key:
+                            description: Name of the key in the referenced Secret
+                              that contain the target data. This field might be optional
+                              if a default value has been defined.
+                            type: string
+                          name:
+                            description: Name of a Secret that is being referenced.
+                            type: string
+                        type: object
+                      truststorePasswordSecretRef:
+                        description: Name of a Secret that contains the TLS truststore
+                          password. Key `ca.password` is assumed by default.
+                        properties:
+                          key:
+                            description: Name of the key in the referenced Secret
+                              that contain the target data. This field might be optional
+                              if a default value has been defined.
+                            type: string
+                          name:
+                            description: Name of a Secret that is being referenced.
+                            type: string
+                        type: object
+                      truststoreSecretRef:
+                        description: Name of a Secret that contains the TLS truststore
+                          (in PKCS12 format). Key `ca.p12` is assumed by default.
+                        properties:
+                          key:
+                            description: Name of the key in the referenced Secret
+                              that contain the target data. This field might be optional
+                              if a default value has been defined.
+                            type: string
+                          name:
+                            description: Name of a Secret that is being referenced.
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              ui:
+                description: |
+                  Configure Apicurio Registry UI component.
+                properties:
+                  enabled:
+                    description: |
+                      Indicates whether the operator should deploy the UI component.  Defaults to `true`.
+                    type: boolean
+                  env:
+                    description: Configure a list of environment variables that will
+                      be passed to this components' container.
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                        valueFrom:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              type: object
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              type: object
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                          type: object
+                      type: object
+                    type: array
+                  host:
+                    description: 'DEPRECATED: Use the `(component).ingress.host` field
+                      instead. The operator will attempt to update the field automatically.'
+                    type: string
+                  ingress:
+                    description: Configure Ingress for the component.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Additional annotations for the operator-managed
+                          Ingress.
+                        type: object
+                      enabled:
+                        description: |
+                          Whether an Ingress should be managed by the operator.  Defaults to 'true'.
+
+                          Set this to 'false' if you want to create your own custom Ingress.
+                        type: boolean
+                      host:
+                        description: |-
+                          Configure hostname of the operator-managed Ingress. If the value is empty, the operator will not create an Ingress resource for the component.
+
+                          IMPORTANT: If the Ingress already exists and the value becomes empty, the Ingress will be deleted.
+                        type: string
+                      ingressClassName:
+                        description: |-
+                          Name of an IngressClass cluster resource. Ingress controller implementations use this field to know whether they should be serving this Ingress resource, by a transitive connection (controller -> IngressClass -> Ingress resource).
+
+                          See https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class.
+                        type: string
+                    type: object
+                  networkPolicy:
+                    description: |2
+                              Configuration of a NetworkPolicy for the component.
+                    properties:
+                      enabled:
+                        description: |
+                          Whether a NetworkPolicy should be managed by the operator.  Defaults to 'true'.
+
+                          Set this to 'false' if you want to create your own custom NetworkPolicy.
+                        type: boolean
+                    type: object
+                  podDisruptionBudget:
+                    description: |
+                      Configuration of a PodDisruptionBudget for the component.
+                    properties:
+                      enabled:
+                        description: |
+                          Whether a PodDisruptionBudget should be managed by the operator.  Defaults to 'true'.
+
+                          Set this to 'false' if you want to create your own custom PodDisruptionBudget.
+                        type: boolean
+                    type: object
+                  podTemplateSpec:
+                    description: |-
+                      `PodTemplateSpec` describes the data a pod should have when created from a template.
+
+                      This template is used by the operator to create the components' Deployment. The operator first extends the template
+                      with default values if required, and then applies additional configuration
+                      based on the other contents of `ApicurioRegistry3` CR.
+                    properties:
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          creationTimestamp:
+                            type: string
+                          deletionGracePeriodSeconds:
+                            type: integer
+                          deletionTimestamp:
+                            type: string
+                          finalizers:
+                            items:
+                              type: string
+                            type: array
+                          generateName:
+                            type: string
+                          generation:
+                            type: integer
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          managedFields:
+                            items:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldsType:
+                                  type: string
+                                fieldsV1:
+                                  type: object
+                                manager:
+                                  type: string
+                                operation:
+                                  type: string
+                                subresource:
+                                  type: string
+                                time:
+                                  type: string
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                          namespace:
+                            type: string
+                          ownerReferences:
+                            items:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                blockOwnerDeletion:
+                                  type: boolean
+                                controller:
+                                  type: boolean
+                                kind:
+                                  type: string
+                                name:
+                                  type: string
+                                uid:
+                                  type: string
+                              type: object
+                            type: array
+                          resourceVersion:
+                            type: string
+                          selfLink:
+                            type: string
+                          uid:
+                            type: string
+                        type: object
+                      spec:
+                        properties:
+                          activeDeadlineSeconds:
+                            type: integer
+                          affinity:
+                            properties:
+                              nodeAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        preference:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                            matchFields:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                          type: object
+                                        weight:
+                                          type: integer
+                                      type: object
+                                    type: array
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    properties:
+                                      nodeSelectorTerms:
+                                        items:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                            matchFields:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                          type: object
+                                        type: array
+                                    type: object
+                                type: object
+                              podAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        podAffinityTerm:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              type: string
+                                          type: object
+                                        weight:
+                                          type: integer
+                                      type: object
+                                    type: array
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                              podAntiAffinity:
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        podAffinityTerm:
+                                          properties:
+                                            labelSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            matchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                            mismatchLabelKeys:
+                                              items:
+                                                type: string
+                                              type: array
+                                            namespaceSelector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            namespaces:
+                                              items:
+                                                type: string
+                                              type: array
+                                            topologyKey:
+                                              type: string
+                                          type: object
+                                        weight:
+                                          type: integer
+                                      type: object
+                                    type: array
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    items:
+                                      properties:
+                                        labelSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        matchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                        mismatchLabelKeys:
+                                          items:
+                                            type: string
+                                          type: array
+                                        namespaceSelector:
+                                          properties:
+                                            matchExpressions:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  operator:
+                                                    type: string
+                                                  values:
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          type: string
+                                      type: object
+                                    type: array
+                                type: object
+                            type: object
+                          automountServiceAccountToken:
+                            type: boolean
+                          containers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            type: object
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            type: object
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: integer
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: integer
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        type: string
+                                    type: object
+                                  type: array
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  items:
+                                    properties:
+                                      resourceName:
+                                        type: string
+                                      restartPolicy:
+                                        type: string
+                                    type: object
+                                  type: array
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  type: string
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        hostProcess:
+                                          type: boolean
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        type: string
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    type: object
+                                  type: array
+                                workingDir:
+                                  type: string
+                              type: object
+                            type: array
+                          dnsConfig:
+                            properties:
+                              nameservers:
+                                items:
+                                  type: string
+                                type: array
+                              options:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                              searches:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          dnsPolicy:
+                            type: string
+                          enableServiceLinks:
+                            type: boolean
+                          ephemeralContainers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            type: object
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            type: object
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: integer
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: integer
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        type: string
+                                    type: object
+                                  type: array
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  items:
+                                    properties:
+                                      resourceName:
+                                        type: string
+                                      restartPolicy:
+                                        type: string
+                                    type: object
+                                  type: array
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  type: string
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        hostProcess:
+                                          type: boolean
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                targetContainerName:
+                                  type: string
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        type: string
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    type: object
+                                  type: array
+                                workingDir:
+                                  type: string
+                              type: object
+                            type: array
+                          hostAliases:
+                            items:
+                              properties:
+                                hostnames:
+                                  items:
+                                    type: string
+                                  type: array
+                                ip:
+                                  type: string
+                              type: object
+                            type: array
+                          hostIPC:
+                            type: boolean
+                          hostNetwork:
+                            type: boolean
+                          hostPID:
+                            type: boolean
+                          hostUsers:
+                            type: boolean
+                          hostname:
+                            type: string
+                          imagePullSecrets:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            type: array
+                          initContainers:
+                            items:
+                              properties:
+                                args:
+                                  items:
+                                    type: string
+                                  type: array
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                                env:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                      valueFrom:
+                                        properties:
+                                          configMapKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            type: object
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            type: object
+                                          secretKeyRef:
+                                            properties:
+                                              key:
+                                                type: string
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                        type: object
+                                    type: object
+                                  type: array
+                                envFrom:
+                                  items:
+                                    properties:
+                                      configMapRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                      prefix:
+                                        type: string
+                                      secretRef:
+                                        properties:
+                                          name:
+                                            type: string
+                                          optional:
+                                            type: boolean
+                                        type: object
+                                    type: object
+                                  type: array
+                                image:
+                                  type: string
+                                imagePullPolicy:
+                                  type: string
+                                lifecycle:
+                                  properties:
+                                    postStart:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: integer
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      properties:
+                                        exec:
+                                          properties:
+                                            command:
+                                              items:
+                                                type: string
+                                              type: array
+                                          type: object
+                                        httpGet:
+                                          properties:
+                                            host:
+                                              type: string
+                                            httpHeaders:
+                                              items:
+                                                properties:
+                                                  name:
+                                                    type: string
+                                                  value:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            path:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              type: string
+                                          type: object
+                                        sleep:
+                                          properties:
+                                            seconds:
+                                              type: integer
+                                          type: object
+                                        tcpSocket:
+                                          properties:
+                                            host:
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              x-kubernetes-int-or-string: true
+                                          type: object
+                                      type: object
+                                  type: object
+                                livenessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                name:
+                                  type: string
+                                ports:
+                                  items:
+                                    properties:
+                                      containerPort:
+                                        type: integer
+                                      hostIP:
+                                        type: string
+                                      hostPort:
+                                        type: integer
+                                      name:
+                                        type: string
+                                      protocol:
+                                        type: string
+                                    type: object
+                                  type: array
+                                readinessProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  items:
+                                    properties:
+                                      resourceName:
+                                        type: string
+                                      restartPolicy:
+                                        type: string
+                                    type: object
+                                  type: array
+                                resources:
+                                  properties:
+                                    claims:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          request:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  type: string
+                                securityContext:
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      type: boolean
+                                    appArmorProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    capabilities:
+                                      properties:
+                                        add:
+                                          items:
+                                            type: string
+                                          type: array
+                                        drop:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    privileged:
+                                      type: boolean
+                                    procMount:
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      type: boolean
+                                    runAsGroup:
+                                      type: integer
+                                    runAsNonRoot:
+                                      type: boolean
+                                    runAsUser:
+                                      type: integer
+                                    seLinuxOptions:
+                                      properties:
+                                        level:
+                                          type: string
+                                        role:
+                                          type: string
+                                        type:
+                                          type: string
+                                        user:
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      properties:
+                                        localhostProfile:
+                                          type: string
+                                        type:
+                                          type: string
+                                      type: object
+                                    windowsOptions:
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          type: string
+                                        hostProcess:
+                                          type: boolean
+                                        runAsUserName:
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  properties:
+                                    exec:
+                                      properties:
+                                        command:
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    failureThreshold:
+                                      type: integer
+                                    grpc:
+                                      properties:
+                                        port:
+                                          type: integer
+                                        service:
+                                          type: string
+                                      type: object
+                                    httpGet:
+                                      properties:
+                                        host:
+                                          type: string
+                                        httpHeaders:
+                                          items:
+                                            properties:
+                                              name:
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        path:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          type: string
+                                      type: object
+                                    initialDelaySeconds:
+                                      type: integer
+                                    periodSeconds:
+                                      type: integer
+                                    successThreshold:
+                                      type: integer
+                                    tcpSocket:
+                                      properties:
+                                        host:
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          x-kubernetes-int-or-string: true
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      type: integer
+                                    timeoutSeconds:
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  type: boolean
+                                stdinOnce:
+                                  type: boolean
+                                terminationMessagePath:
+                                  type: string
+                                terminationMessagePolicy:
+                                  type: string
+                                tty:
+                                  type: boolean
+                                volumeDevices:
+                                  items:
+                                    properties:
+                                      devicePath:
+                                        type: string
+                                      name:
+                                        type: string
+                                    type: object
+                                  type: array
+                                volumeMounts:
+                                  items:
+                                    properties:
+                                      mountPath:
+                                        type: string
+                                      mountPropagation:
+                                        type: string
+                                      name:
+                                        type: string
+                                      readOnly:
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        type: string
+                                      subPath:
+                                        type: string
+                                      subPathExpr:
+                                        type: string
+                                    type: object
+                                  type: array
+                                workingDir:
+                                  type: string
+                              type: object
+                            type: array
+                          nodeName:
+                            type: string
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          os:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          overhead:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              x-kubernetes-int-or-string: true
+                            type: object
+                          preemptionPolicy:
+                            type: string
+                          priority:
+                            type: integer
+                          priorityClassName:
+                            type: string
+                          readinessGates:
+                            items:
+                              properties:
+                                conditionType:
+                                  type: string
+                              type: object
+                            type: array
+                          resourceClaims:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                resourceClaimName:
+                                  type: string
+                                resourceClaimTemplateName:
+                                  type: string
+                              type: object
+                            type: array
+                          resources:
+                            properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    request:
+                                      type: string
+                                  type: object
+                                type: array
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          restartPolicy:
+                            type: string
+                          runtimeClassName:
+                            type: string
+                          schedulerName:
+                            type: string
+                          schedulingGates:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            type: array
+                          securityContext:
+                            properties:
+                              appArmorProfile:
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
+                                type: object
+                              fsGroup:
+                                type: integer
+                              fsGroupChangePolicy:
+                                type: string
+                              runAsGroup:
+                                type: integer
+                              runAsNonRoot:
+                                type: boolean
+                              runAsUser:
+                                type: integer
+                              seLinuxChangePolicy:
+                                type: string
+                              seLinuxOptions:
+                                properties:
+                                  level:
+                                    type: string
+                                  role:
+                                    type: string
+                                  type:
+                                    type: string
+                                  user:
+                                    type: string
+                                type: object
+                              seccompProfile:
+                                properties:
+                                  localhostProfile:
+                                    type: string
+                                  type:
+                                    type: string
+                                type: object
+                              supplementalGroups:
+                                items:
+                                  type: integer
+                                type: array
+                              supplementalGroupsPolicy:
+                                type: string
+                              sysctls:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  type: object
+                                type: array
+                              windowsOptions:
+                                properties:
+                                  gmsaCredentialSpec:
+                                    type: string
+                                  gmsaCredentialSpecName:
+                                    type: string
+                                  hostProcess:
+                                    type: boolean
+                                  runAsUserName:
+                                    type: string
+                                type: object
+                            type: object
+                          serviceAccount:
+                            type: string
+                          serviceAccountName:
+                            type: string
+                          setHostnameAsFQDN:
+                            type: boolean
+                          shareProcessNamespace:
+                            type: boolean
+                          subdomain:
+                            type: string
+                          terminationGracePeriodSeconds:
+                            type: integer
+                          tolerations:
+                            items:
+                              properties:
+                                effect:
+                                  type: string
+                                key:
+                                  type: string
+                                operator:
+                                  type: string
+                                tolerationSeconds:
+                                  type: integer
+                                value:
+                                  type: string
+                              type: object
+                            type: array
+                          topologySpreadConstraints:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                matchLabelKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                maxSkew:
+                                  type: integer
+                                minDomains:
+                                  type: integer
+                                nodeAffinityPolicy:
+                                  type: string
+                                nodeTaintsPolicy:
+                                  type: string
+                                topologyKey:
+                                  type: string
+                                whenUnsatisfiable:
+                                  type: string
+                              type: object
+                            type: array
+                          volumes:
+                            items:
+                              properties:
+                                awsElasticBlockStore:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    partition:
+                                      type: integer
+                                    readOnly:
+                                      type: boolean
+                                    volumeID:
+                                      type: string
+                                  type: object
+                                azureDisk:
+                                  properties:
+                                    cachingMode:
+                                      type: string
+                                    diskName:
+                                      type: string
+                                    diskURI:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    kind:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  type: object
+                                azureFile:
+                                  properties:
+                                    readOnly:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                    shareName:
+                                      type: string
+                                  type: object
+                                cephfs:
+                                  properties:
+                                    monitors:
+                                      items:
+                                        type: string
+                                      type: array
+                                    path:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretFile:
+                                      type: string
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    user:
+                                      type: string
+                                  type: object
+                                cinder:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    volumeID:
+                                      type: string
+                                  type: object
+                                configMap:
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                csi:
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    nodePublishSecretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    readOnly:
+                                      type: boolean
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                downwardAPI:
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            type: object
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                                emptyDir:
+                                  properties:
+                                    medium:
+                                      type: string
+                                    sizeLimit:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                ephemeral:
+                                  properties:
+                                    volumeClaimTemplate:
+                                      properties:
+                                        metadata:
+                                          properties:
+                                            annotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            creationTimestamp:
+                                              type: string
+                                            deletionGracePeriodSeconds:
+                                              type: integer
+                                            deletionTimestamp:
+                                              type: string
+                                            finalizers:
+                                              items:
+                                                type: string
+                                              type: array
+                                            generateName:
+                                              type: string
+                                            generation:
+                                              type: integer
+                                            labels:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
+                                            managedFields:
+                                              items:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldsType:
+                                                    type: string
+                                                  fieldsV1:
+                                                    type: object
+                                                  manager:
+                                                    type: string
+                                                  operation:
+                                                    type: string
+                                                  subresource:
+                                                    type: string
+                                                  time:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            namespace:
+                                              type: string
+                                            ownerReferences:
+                                              items:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  blockOwnerDeletion:
+                                                    type: boolean
+                                                  controller:
+                                                    type: boolean
+                                                  kind:
+                                                    type: string
+                                                  name:
+                                                    type: string
+                                                  uid:
+                                                    type: string
+                                                type: object
+                                              type: array
+                                            resourceVersion:
+                                              type: string
+                                            selfLink:
+                                              type: string
+                                            uid:
+                                              type: string
+                                          type: object
+                                        spec:
+                                          properties:
+                                            accessModes:
+                                              items:
+                                                type: string
+                                              type: array
+                                            dataSource:
+                                              properties:
+                                                apiGroup:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                              type: object
+                                            dataSourceRef:
+                                              properties:
+                                                apiGroup:
+                                                  type: string
+                                                kind:
+                                                  type: string
+                                                name:
+                                                  type: string
+                                                namespace:
+                                                  type: string
+                                              type: object
+                                            resources:
+                                              properties:
+                                                limits:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  type: object
+                                                requests:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    x-kubernetes-int-or-string: true
+                                                  type: object
+                                              type: object
+                                            selector:
+                                              properties:
+                                                matchExpressions:
+                                                  items:
+                                                    properties:
+                                                      key:
+                                                        type: string
+                                                      operator:
+                                                        type: string
+                                                      values:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  type: array
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              type: object
+                                            storageClassName:
+                                              type: string
+                                            volumeAttributesClassName:
+                                              type: string
+                                            volumeMode:
+                                              type: string
+                                            volumeName:
+                                              type: string
+                                          type: object
+                                      type: object
+                                  type: object
+                                fc:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    lun:
+                                      type: integer
+                                    readOnly:
+                                      type: boolean
+                                    targetWWNs:
+                                      items:
+                                        type: string
+                                      type: array
+                                    wwids:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                flexVolume:
+                                  properties:
+                                    driver:
+                                      type: string
+                                    fsType:
+                                      type: string
+                                    options:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                  type: object
+                                flocker:
+                                  properties:
+                                    datasetName:
+                                      type: string
+                                    datasetUUID:
+                                      type: string
+                                  type: object
+                                gcePersistentDisk:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    partition:
+                                      type: integer
+                                    pdName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  type: object
+                                gitRepo:
+                                  properties:
+                                    directory:
+                                      type: string
+                                    repository:
+                                      type: string
+                                    revision:
+                                      type: string
+                                  type: object
+                                glusterfs:
+                                  properties:
+                                    endpoints:
+                                      type: string
+                                    path:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  type: object
+                                hostPath:
+                                  properties:
+                                    path:
+                                      type: string
+                                    type:
+                                      type: string
+                                  type: object
+                                image:
+                                  properties:
+                                    pullPolicy:
+                                      type: string
+                                    reference:
+                                      type: string
+                                  type: object
+                                iscsi:
+                                  properties:
+                                    chapAuthDiscovery:
+                                      type: boolean
+                                    chapAuthSession:
+                                      type: boolean
+                                    fsType:
+                                      type: string
+                                    initiatorName:
+                                      type: string
+                                    iqn:
+                                      type: string
+                                    iscsiInterface:
+                                      type: string
+                                    lun:
+                                      type: integer
+                                    portals:
+                                      items:
+                                        type: string
+                                      type: array
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    targetPortal:
+                                      type: string
+                                  type: object
+                                name:
+                                  type: string
+                                nfs:
+                                  properties:
+                                    path:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    server:
+                                      type: string
+                                  type: object
+                                persistentVolumeClaim:
+                                  properties:
+                                    claimName:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                  type: object
+                                photonPersistentDisk:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    pdID:
+                                      type: string
+                                  type: object
+                                portworxVolume:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    volumeID:
+                                      type: string
+                                  type: object
+                                projected:
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    sources:
+                                      items:
+                                        properties:
+                                          clusterTrustBundle:
+                                            properties:
+                                              labelSelector:
+                                                properties:
+                                                  matchExpressions:
+                                                    items:
+                                                      properties:
+                                                        key:
+                                                          type: string
+                                                        operator:
+                                                          type: string
+                                                        values:
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      type: object
+                                                    type: array
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    type: object
+                                                type: object
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                              path:
+                                                type: string
+                                              signerName:
+                                                type: string
+                                            type: object
+                                          configMap:
+                                            properties:
+                                              items:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    mode:
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                          downwardAPI:
+                                            properties:
+                                              items:
+                                                items:
+                                                  properties:
+                                                    fieldRef:
+                                                      properties:
+                                                        apiVersion:
+                                                          type: string
+                                                        fieldPath:
+                                                          type: string
+                                                      type: object
+                                                    mode:
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                    resourceFieldRef:
+                                                      properties:
+                                                        containerName:
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          type: string
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          secret:
+                                            properties:
+                                              items:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    mode:
+                                                      type: integer
+                                                    path:
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              name:
+                                                type: string
+                                              optional:
+                                                type: boolean
+                                            type: object
+                                          serviceAccountToken:
+                                            properties:
+                                              audience:
+                                                type: string
+                                              expirationSeconds:
+                                                type: integer
+                                              path:
+                                                type: string
+                                            type: object
+                                        type: object
+                                      type: array
+                                  type: object
+                                quobyte:
+                                  properties:
+                                    group:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    registry:
+                                      type: string
+                                    tenant:
+                                      type: string
+                                    user:
+                                      type: string
+                                    volume:
+                                      type: string
+                                  type: object
+                                rbd:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    image:
+                                      type: string
+                                    keyring:
+                                      type: string
+                                    monitors:
+                                      items:
+                                        type: string
+                                      type: array
+                                    pool:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    user:
+                                      type: string
+                                  type: object
+                                scaleIO:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    gateway:
+                                      type: string
+                                    protectionDomain:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    sslEnabled:
+                                      type: boolean
+                                    storageMode:
+                                      type: string
+                                    storagePool:
+                                      type: string
+                                    system:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  type: object
+                                secret:
+                                  properties:
+                                    defaultMode:
+                                      type: integer
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            type: integer
+                                          path:
+                                            type: string
+                                        type: object
+                                      type: array
+                                    optional:
+                                      type: boolean
+                                    secretName:
+                                      type: string
+                                  type: object
+                                storageos:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                      type: object
+                                    volumeName:
+                                      type: string
+                                    volumeNamespace:
+                                      type: string
+                                  type: object
+                                vsphereVolume:
+                                  properties:
+                                    fsType:
+                                      type: string
+                                    storagePolicyID:
+                                      type: string
+                                    storagePolicyName:
+                                      type: string
+                                    volumePath:
+                                      type: string
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  replicas:
+                    description: Number of replicas for the component
+                    type: integer
+                type: object
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Apicurio Registry operator and operand conditions.
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: |
+                        The last time the condition transitioned from one status to another.
+                      type: string
+                    lastUpdateTime:
+                      description: |
+                        The last time that the condition was updated by the operator.
+                        Unlike the `lastTransitionTime` field, this timestamp is updated even if the status has not changed.
+                      type: string
+                    message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      type: string
+                    reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "False"
+                      - "True"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - lastUpdateTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: The latest generation of the ApicurioRegistry3 resource
+                  that this status has been updated for.
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: apicurio-registry-operator
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: apicurio-registry-operator
+    app.kubernetes.io/name: apicurio-registry-operator
+    app.kubernetes.io/part-of: apicurio-registry
+    app.kubernetes.io/version: 3.1.1
+  name: apicurio-registry-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: apicurio-registry-operator
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: apicurio-registry-operator
+    app.kubernetes.io/name: apicurio-registry-operator
+    app.kubernetes.io/part-of: apicurio-registry
+    app.kubernetes.io/version: 3.1.1
+  name: apicurio-registry-operator-clusterrole
+rules:
+- apiGroups:
+  - registry.apicur.io
+  resources:
+  - apicurioregistries3
+  - apicurioregistries3/status
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - '*'
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - apicurioregistries3.registry.apicur.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  - networkpolicies
+  verbs:
+  - '*'
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: apicurio-registry-operator
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: apicurio-registry-operator
+    app.kubernetes.io/name: apicurio-registry-operator
+    app.kubernetes.io/part-of: apicurio-registry
+    app.kubernetes.io/version: 3.1.1
+  name: apicurio-registry-operator-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: apicurio-registry-operator-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: apicurio-registry-operator
+  namespace: $OPERATOR_NAMESPACE
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: apicurio-registry-operator
+    app.kubernetes.io/component: operator
+    app.kubernetes.io/instance: apicurio-registry-operator
+    app.kubernetes.io/name: apicurio-registry-operator
+    app.kubernetes.io/part-of: apicurio-registry
+    app.kubernetes.io/version: 3.1.1
+  name: apicurio-registry-operator-v3.1.1
+  namespace: $OPERATOR_NAMESPACE
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: apicurio-registry-operator
+      app.kubernetes.io/component: operator
+      app.kubernetes.io/instance: apicurio-registry-operator
+      app.kubernetes.io/name: apicurio-registry-operator
+      app.kubernetes.io/part-of: apicurio-registry
+      app.kubernetes.io/version: 3.1.1
+  template:
+    metadata:
+      labels:
+        app: apicurio-registry-operator
+        app.kubernetes.io/component: operator
+        app.kubernetes.io/instance: apicurio-registry-operator
+        app.kubernetes.io/name: apicurio-registry-operator
+        app.kubernetes.io/part-of: apicurio-registry
+        app.kubernetes.io/version: 3.1.1
+    spec:
+      containers:
+      - env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: APICURIO_OPERATOR_WATCHED_NAMESPACES
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['olm.targetNamespaces']
+        - name: QUARKUS_PROFILE
+          value: prod
+        - name: REGISTRY_APP_IMAGE
+          value: $REGISTRY_APP_IMAGE
+        - name: REGISTRY_UI_IMAGE
+          value: $REGISTRY_UI_IMAGE
+        image: $REGISTRY_OPERATOR_IMAGE
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /q/health/live
+            port: 8080
+        name: apicurio-registry-operator
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /q/health/ready
+            port: 8080
+        resources:
+          limits:
+            cpu: 200m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        startupProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /q/health/started
+            port: 8080
+      serviceAccountName: apicurio-registry-operator


### PR DESCRIPTION
## Summary

This PR migrates the apicurio-testing infrastructure from OKD (OKD Kubernetes Distribution) to OCP (OpenShift Container Platform):

- Added comprehensive migration documentation and plan in `docs/MIGRATE-TO-OCP.md`
- Created new `download-ocp-installer.sh` script to download OCP installers
- Updated `generate-install-config.sh` to support OCP configuration
- Added OCP install-config templates for versions 4.16 and 4.19
- Updated GitHub workflows to use OCP instead of OKD (provision, destroy, and test workflows)
- Updated cluster installation scripts to use OCP
- Added Apicurio Registry Operator 3.1.1 template
- Updated pull secret configuration script

## Test plan

- [ ] Verify OCP installer download script works correctly
- [ ] Test install-config generation for OCP 4.16 and 4.19
- [ ] Run cluster provisioning workflow with OCP
- [ ] Verify registry operator and release tests work with OCP
- [ ] Test cluster destruction workflow
- [ ] Validate migration documentation is complete and accurate