### PR TITLE
Fix PostgreSQL probe variable substitution in Keycloak install

### DIFF
--- a/install-apicurio-registry.sh
+++ b/install-apicurio-registry.sh
@@ -372,7 +372,13 @@ fi
 
 # Wait for the health endpoint to be ready
 echo "Waiting for Apicurio Registry health endpoint to be ready..."
-HEALTH_URL="http://$APP_INGRESS_URL/health/ready"
+# Use HTTPS for profiles that configure TLS on routes (e.g., authn)
+if [[ "$PROFILE" == "authn" ]]; then
+    HEALTH_PROTOCOL="https"
+else
+    HEALTH_PROTOCOL="http"
+fi
+HEALTH_URL="$HEALTH_PROTOCOL://$APP_INGRESS_URL/health/ready"
 wait_for_health_endpoint "$HEALTH_URL"
 if [[ $? -ne 0 ]]; then
   echo ""
@@ -389,6 +395,6 @@ fi
 echo "Apicurio Registry is up!"
 echo ""
 echo "You can access the application here:"
-echo "    User Interface: http://$UI_INGRESS_URL"
-echo "    REST API:       http://$APP_INGRESS_URL"
+echo "    User Interface: $HEALTH_PROTOCOL://$UI_INGRESS_URL"
+echo "    REST API:       $HEALTH_PROTOCOL://$APP_INGRESS_URL"
 echo ""

--- a/install-keycloak.sh
+++ b/install-keycloak.sh
@@ -367,6 +367,8 @@ export APPS_URL="apps.$CLUSTER_NAME.$BASE_DOMAIN"
 export KEYCLOAK_INGRESS_URL="keycloak-$NAMESPACE.$APPS_URL"
 export KEYCLOAK_HEALTH_URL="keycloak-health-$NAMESPACE.$APPS_URL"
 export KEYCLOAK_DB_PASSWORD
+export POSTGRES_USER="keycloak"
+export POSTGRES_DB="keycloak"
 
 mkdir -p $APP_DIR
 


### PR DESCRIPTION
Export POSTGRES_USER and POSTGRES_DB environment variables so that envsubst correctly substitutes these values in the PostgreSQL deployment template's readiness/liveness probe commands.

Without this fix, envsubst replaces ${POSTGRES_USER} and ${POSTGRES_DB} with empty strings, causing the probe command to fail with: "FATAL: role '-d' does not exist"

I have also update the probe path for the Keycloak case, since this one uses tls.