### PR TITLE
Add explicit directory configuration for certbot

### DIFF
--- a/install-tls-cert.sh
+++ b/install-tls-cert.sh
@@ -338,7 +338,7 @@ fi
 
 # Run certbot command
 echo "Running certbot to generate certificate for domain: $DOMAIN"
-CERTBOT_CMD="certbot certonly --dns-route53 -d \"$DOMAIN\" --agree-tos --email \"$EMAIL\" --non-interactive"
+CERTBOT_CMD="certbot certonly --dns-route53 -d \"$DOMAIN\" --agree-tos --email \"$EMAIL\" --non-interactive --config-dir /etc/letsencrypt --work-dir /var/lib/letsencrypt --logs-dir /var/log/letsencrypt"
 echo "Executing: $CERTBOT_CMD"
 
 if kubectl exec certbot-pod -n "$NAMESPACE" -- sh -c "$CERTBOT_CMD"; then

--- a/templates/certbot-pod.yaml
+++ b/templates/certbot-pod.yaml
@@ -29,6 +29,10 @@ spec:
     volumeMounts:
     - name: letsencrypt
       mountPath: /etc/letsencrypt
+    - name: letsencrypt-work
+      mountPath: /var/lib/letsencrypt
+    - name: letsencrypt-logs
+      mountPath: /var/log/letsencrypt
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -40,4 +44,8 @@ spec:
         type: RuntimeDefault
   volumes:
   - name: letsencrypt
+    emptyDir: {}
+  - name: letsencrypt-work
+    emptyDir: {}
+  - name: letsencrypt-logs
     emptyDir: {}


### PR DESCRIPTION
## Summary
This PR includes two improvements to the TLS certificate installation process:

1. **Fix certificate caching logic for git-stored certificates** - Replace file timestamp checking with actual certificate expiration date parsing
2. **Add explicit directory configuration for certbot** - Configure certbot to use explicit paths instead of relying on defaults

## Changes

### Certificate Caching Fix (commit 8fedb61)
The previous caching logic relied on file modification timestamps to determine if a certificate needed renewal. This broke when certificates were loaded from a git repository, as file timestamps reflect the git clone time rather than the actual certificate creation time.

**Changes:**
- Read certificate expiration date directly from the cert using OpenSSL
- Check actual days until expiration instead of file age
- Reduce renewal threshold from 60 to 15 days before expiration
- Add certificate corruption validation
- Support both Linux (GNU date) and macOS (BSD date) platforms

### Certbot Directory Configuration (commit 58f675d)
Configure certbot to use explicit paths for config, work, and logs directories to ensure consistent behavior in containerized environments.

**Changes:**
- Modified `install-tls-cert.sh` to include `--config-dir`, `--work-dir`, and `--logs-dir` flags in the certbot command
- Updated `templates/certbot-pod.yaml` to add volume mounts for `/var/lib/letsencrypt` (work) and `/var/log/letsencrypt` (logs)

## Benefits
- Certificate caching now works correctly when certs are stored in git
- More accurate renewal timing based on actual expiration dates
- Prevents potential issues with default directory locations in containerized environments
- Properly isolates certbot working directories within the pod's ephemeral storage

## Test plan
- [x] Test certificate caching with git-stored certificates
- [x] Verify renewal triggers at appropriate expiration threshold
- [x] Deploy certbot pod with updated configuration
- [x] Run certificate generation and verify all directories are correctly mounted and accessible
- [x] Confirm certificates are generated successfully with explicit directory paths