### PR TITLE
Upgrade OpenShift testing from 4.19 to 4.20 and add README

### DIFF
--- a/.github/workflows/infra-provision-artifact-cluster.yaml
+++ b/.github/workflows/infra-provision-artifact-cluster.yaml
@@ -23,7 +23,7 @@ jobs:
     uses: ./.github/workflows/infra-provision-cluster.yaml
     with:
       cluster-name: ${{ inputs.cluster-name }}
-      cluster-version: "4.19"
+      cluster-version: "4.20"
       control-nodes: 3
       compute-nodes: 2
       force: true

--- a/.github/workflows/infra-provision-cluster.yaml
+++ b/.github/workflows/infra-provision-cluster.yaml
@@ -22,9 +22,9 @@ on:
         description: OCP version to install
         options:
           - "4.16"
-          - "4.19"
+          - "4.20"
         required: true
-        default: "4.19"
+        default: "4.20"
       force:
         type: boolean
         description: |

--- a/.github/workflows/subtest-registry-operator.yaml
+++ b/.github/workflows/subtest-registry-operator.yaml
@@ -9,7 +9,7 @@ on:
         description: >-
           Name of the test cluster. Can be a new cluster created by this workflow, or an existing cluster.
         required: true
-        default: ci419
+        default: ci420
       skip-provision-cluster:
         type: boolean
         description: Use an existing test cluster.
@@ -20,9 +20,9 @@ on:
         description: Version of the test cluster (required if not using an existing cluster).
         options:
           - "4.16"
-          - "4.19"
+          - "4.20"
         required: false
-        default: "4.19"
+        default: "4.20"
       # Test configuration:
       release-version:
         type: string

--- a/.github/workflows/test-registry-operator.yaml
+++ b/.github/workflows/test-registry-operator.yaml
@@ -33,14 +33,14 @@ on:
         type: string
         description: >-
           Upstream or downstream catalog image(s) in the `cluster-version=catalog-image,…` format, for example:
-          `4.16=image-registry-infra.apps.art.apicurio-testing.org/rh-osbs/iib:123,4.19=image-registry-infra.apps.art.apicurio-testing.org/rh-osbs/iib:456`.
+          `4.16=image-registry-infra.apps.art.apicurio-testing.org/rh-osbs/iib:123,4.20=image-registry-infra.apps.art.apicurio-testing.org/rh-osbs/iib:456`.
           Upstream OLM catalog image can be the latest one, i.e. `quay.io/apicurio/apicurio-registry-3-operator-catalog:latest`.
           Downstream catalog image is assumed to be hosted on the artifact cluster, 
           but the original downstream image URI can also be used and the workflow will attempt to transform the URI.
         required: true
         default: >
           4.16=,
-          4.19=
+          4.20=
       package-version:
         type: string
         description: >-

--- a/.github/workflows/test-registry-release.yaml
+++ b/.github/workflows/test-registry-release.yaml
@@ -148,8 +148,8 @@ jobs:
           echo "run-id=${{ github.run_id }}" >> $GITHUB_OUTPUT
           echo "run-date=$(date -u +%Y-%m-%d)" >> $GITHUB_OUTPUT
 
-  os419:
-    name: OpenShift 4.19
+  os420:
+    name: OpenShift 4.20
     runs-on: ubuntu-latest
     timeout-minutes: 90
 
@@ -159,8 +159,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: "us-east-1"
-      OPENSHIFT_VERSION: "4.19"
-      CLUSTER_NAME: ci419
+      OPENSHIFT_VERSION: "4.20"
+      CLUSTER_NAME: ci420
       APICURIO_REGISTRY_VERSION: ${{ inputs.releaseVersion }}
       CONTROL_PLANE_NODES: 3
       COMPUTE_NODES: 3 # TODO: Increase if needed.
@@ -223,14 +223,14 @@ jobs:
         if: ${{ inputs.skipClusterInstall != 'true' && always() }}
         uses: ./.github/actions/save-cluster-state
 
-  os419_inmemory:
+  os420_inmemory:
     name: Apicurio Registry (in-memory)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: os419
+    needs: os420
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: inmemory
       PROFILE: inmemory
       DOCKER_SERVER: ${{ secrets.DOCKER_SERVER }}
@@ -270,15 +270,15 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_pg17:
+  os420_pg17:
     name: Apicurio Registry (pg 17)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: os419
+    needs: os420
     if: always()
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: pg17
       PROFILE: postgresql
       POSTGRESQL_VERSION: 17
@@ -322,15 +322,15 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_pg12:
+  os420_pg12:
     name: Apicurio Registry (pg12)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: os419
+    needs: os420
     if: always()
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: pg12
       PROFILE: postgresql
       POSTGRESQL_VERSION: 12
@@ -374,15 +374,15 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_mysql84:
+  os420_mysql84:
     name: Apicurio Registry (mysql 8.4)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: os419
+    needs: os420
     if: always()
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: mysql84
       PROFILE: mysql
       MYSQL_VERSION: 8.4
@@ -426,15 +426,15 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_mysql80:
+  os420_mysql80:
     name: Apicurio Registry (mysql 8.0)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: os419
+    needs: os420
     if: always()
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: mysql80
       PROFILE: mysql
       MYSQL_VERSION: 8.0
@@ -478,15 +478,15 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_strimzi047:
+  os420_strimzi047:
     name: Apicurio Registry (strimzi 0.47)
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    needs: os419
+    needs: os420
     if: always()
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: ksql047
       PROFILE: kafkasql
       STRIMZI_VERSION: 0.47.0
@@ -535,15 +535,15 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_keycloak26:
+  os420_keycloak26:
     name: Apicurio Registry (keycloak 26)
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    needs: os419
+    needs: os420
     if: always()
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: keycloak26
       PROFILE: authn
       KEYCLOAK_VERSION: 26.3.1
@@ -592,15 +592,15 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_keycloak22:
+  os420_keycloak22:
     name: Apicurio Registry (keycloak 22)
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    needs: os419
+    needs: os420
     if: always()
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: keycloak22
       PROFILE: authn
       KEYCLOAK_VERSION: 22.0.3
@@ -650,14 +650,14 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_inmemory_uitests:
+  os420_inmemory_uitests:
     name: UI Tests (in mem)
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    needs: os419_inmemory
+    needs: os420_inmemory
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: inmemory
       APICURIO_REGISTRY_VERSION: ${{ inputs.releaseVersion }}
       IS_DOWNSTREAM_VERSION: ${{ inputs.isDownstream }}
@@ -698,14 +698,14 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_inmemory_integrationtests:
+  os420_inmemory_integrationtests:
     name: Integration Tests (in mem)
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    needs: os419_inmemory_uitests
+    needs: os420_inmemory_uitests
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: inmemory
       APICURIO_REGISTRY_VERSION: ${{ inputs.releaseVersion }}
 
@@ -748,14 +748,14 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_inmemory_dastscan:
+  os420_inmemory_dastscan:
     name: DAST Scan (in mem)
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: os419_inmemory_integrationtests
+    needs: os420_inmemory_integrationtests
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: inmemory
       RAPIDAST_TAG: development
 
@@ -815,14 +815,14 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_pg17_uitests:
+  os420_pg17_uitests:
     name: UI Tests (pg17)
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    needs: os419_pg17
+    needs: os420_pg17
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: pg17
       APICURIO_REGISTRY_VERSION: ${{ inputs.releaseVersion }}
       IS_DOWNSTREAM_VERSION: ${{ inputs.isDownstream }}
@@ -863,14 +863,14 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_pg17_integrationtests:
+  os420_pg17_integrationtests:
     name: Integration Tests (pg17)
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    needs: os419_pg17_uitests
+    needs: os420_pg17_uitests
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: pg17
       APICURIO_REGISTRY_VERSION: ${{ inputs.releaseVersion }}
       TEST_PROFILE: all
@@ -914,14 +914,14 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_pg12_integrationtests:
+  os420_pg12_integrationtests:
     name: Integration Tests (pg12)
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    needs: os419_pg12
+    needs: os420_pg12
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: pg12
       APICURIO_REGISTRY_VERSION: ${{ inputs.releaseVersion }}
       TEST_PROFILE: smoke
@@ -965,14 +965,14 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_mysql84_uitests:
+  os420_mysql84_uitests:
     name: UI Tests (mysql 8.4)
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    needs: os419_mysql84
+    needs: os420_mysql84
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: mysql84
       APICURIO_REGISTRY_VERSION: ${{ inputs.releaseVersion }}
       IS_DOWNSTREAM_VERSION: ${{ inputs.isDownstream }}
@@ -1013,14 +1013,14 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_mysql80_uitests:
+  os420_mysql80_uitests:
     name: UI Tests (mysql 8.0)
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    needs: os419_mysql80
+    needs: os420_mysql80
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: mysql80
       APICURIO_REGISTRY_VERSION: ${{ inputs.releaseVersion }}
       IS_DOWNSTREAM_VERSION: ${{ inputs.isDownstream }}
@@ -1061,14 +1061,14 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_mysql84_integrationtests:
+  os420_mysql84_integrationtests:
     name: Integration Tests (mysql 8.4)
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    needs: os419_mysql84_uitests
+    needs: os420_mysql84_uitests
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: mysql84
       APICURIO_REGISTRY_VERSION: ${{ inputs.releaseVersion }}
       TEST_PROFILE: all
@@ -1112,14 +1112,14 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_mysql80_integrationtests:
+  os420_mysql80_integrationtests:
     name: Integration Tests (mysql 8.0)
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    needs: os419_mysql80_uitests
+    needs: os420_mysql80_uitests
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: mysql80
       APICURIO_REGISTRY_VERSION: ${{ inputs.releaseVersion }}
       TEST_PROFILE: smoke
@@ -1163,14 +1163,14 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_strimzi047_uitests:
+  os420_strimzi047_uitests:
     name: UI Tests (strimzi 0.47)
     runs-on: ubuntu-latest
     timeout-minutes: 25
-    needs: os419_strimzi047
+    needs: os420_strimzi047
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: ksql047
       APICURIO_REGISTRY_VERSION: ${{ inputs.releaseVersion }}
       IS_DOWNSTREAM_VERSION: ${{ inputs.isDownstream }}
@@ -1211,14 +1211,14 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_strimzi047_integrationtests:
+  os420_strimzi047_integrationtests:
     name: Integration Tests (strimzi 0.47)
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    needs: os419_strimzi047_uitests
+    needs: os420_strimzi047_uitests
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: ksql047
       APICURIO_REGISTRY_VERSION: ${{ inputs.releaseVersion }}
 
@@ -1261,14 +1261,14 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_keycloak26_integrationtests:
+  os420_keycloak26_integrationtests:
     name: Integration Tests (keycloak 26)
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    needs: os419_keycloak26
+    needs: os420_keycloak26
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: keycloak26
       APICURIO_REGISTRY_VERSION: ${{ inputs.releaseVersion }}
       TEST_PROFILE: auth
@@ -1312,14 +1312,14 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_keycloak22_integrationtests:
+  os420_keycloak22_integrationtests:
     name: Integration Tests (keycloak 22)
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    needs: os419_keycloak22
+    needs: os420_keycloak22
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: keycloak22
       APICURIO_REGISTRY_VERSION: ${{ inputs.releaseVersion }}
       TEST_PROFILE: auth
@@ -1363,14 +1363,14 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_keycloak26_dastscan:
+  os420_keycloak26_dastscan:
     name: DAST Scan (keycloak 26)
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: os419_keycloak26_integrationtests
+    needs: os420_keycloak26_integrationtests
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: keycloak26
       RAPIDAST_TAG: development
 
@@ -1430,18 +1430,18 @@ jobs:
           github-token: ${{ secrets.ACCESS_TOKEN }}
 
 
-  os419_inmemory_teardown:
+  os420_inmemory_teardown:
     name: Destroy Registry (inmemory)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
-      - os419_inmemory_uitests
-      - os419_inmemory_integrationtests
-      - os419_inmemory_dastscan
+      - os420_inmemory_uitests
+      - os420_inmemory_integrationtests
+      - os420_inmemory_dastscan
     if: always()
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: inmemory
 
     steps:
@@ -1459,17 +1459,17 @@ jobs:
           ./destroy-namespace.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE
 
 
-  os419_pg17_teardown:
+  os420_pg17_teardown:
     name: Destroy Registry (pg17)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
-      - os419_pg17_uitests
-      - os419_pg17_integrationtests
+      - os420_pg17_uitests
+      - os420_pg17_integrationtests
     if: always()
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: pg17
 
     steps:
@@ -1487,16 +1487,16 @@ jobs:
           ./destroy-namespace.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE
 
 
-  os419_pg12_teardown:
+  os420_pg12_teardown:
     name: Destroy Registry (pg12)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
-      - os419_pg12_integrationtests
+      - os420_pg12_integrationtests
     if: always()
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: pg12
 
     steps:
@@ -1514,17 +1514,17 @@ jobs:
           ./destroy-namespace.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE
 
 
-  os419_mysql84_teardown:
+  os420_mysql84_teardown:
     name: Destroy Registry (mysql 8.4)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
-      - os419_mysql84_uitests
-      - os419_mysql84_integrationtests
+      - os420_mysql84_uitests
+      - os420_mysql84_integrationtests
     if: always()
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: mysql84
 
     steps:
@@ -1542,16 +1542,16 @@ jobs:
           ./destroy-namespace.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE
 
 
-  os419_mysql80_teardown:
+  os420_mysql80_teardown:
     name: Destroy Registry (mysql 8.0)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
-      - os419_mysql80_integrationtests
+      - os420_mysql80_integrationtests
     if: always()
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: mysql80
 
     steps:
@@ -1569,17 +1569,17 @@ jobs:
           ./destroy-namespace.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE
 
 
-  os419_strimzi047_teardown:
+  os420_strimzi047_teardown:
     name: Destroy Registry (strimzi 0.47)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
-      - os419_strimzi047_uitests
-      - os419_strimzi047_integrationtests
+      - os420_strimzi047_uitests
+      - os420_strimzi047_integrationtests
     if: always()
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: ksql047
 
     steps:
@@ -1597,17 +1597,17 @@ jobs:
           ./destroy-namespace.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE
 
 
-  os419_keycloak26_teardown:
+  os420_keycloak26_teardown:
     name: Destroy Registry (keycloak 26)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
-      - os419_keycloak26_integrationtests
-      - os419_keycloak26_dastscan
+      - os420_keycloak26_integrationtests
+      - os420_keycloak26_dastscan
     if: always()
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: keycloak26
 
     steps:
@@ -1625,16 +1625,16 @@ jobs:
           ./destroy-namespace.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE
 
 
-  os419_keycloak22_teardown:
+  os420_keycloak22_teardown:
     name: Destroy Registry (keycloak 22)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs:
-      - os419_keycloak22_integrationtests
+      - os420_keycloak22_integrationtests
     if: always()
 
     env:
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
       NAMESPACE: keycloak22
 
     steps:
@@ -1652,20 +1652,20 @@ jobs:
           ./destroy-namespace.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE
 
 
-  os419_teardown:
-    name: Destroy OpenShift 4.19
+  os420_teardown:
+    name: Destroy OpenShift 4.20
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs:
       - initialize-globals
-      - os419_inmemory_teardown
-      - os419_pg17_teardown
-      - os419_pg12_teardown
-      - os419_mysql84_teardown
-      - os419_mysql80_teardown
-      - os419_strimzi047_teardown
-      - os419_keycloak26_teardown
-      - os419_keycloak22_teardown
+      - os420_inmemory_teardown
+      - os420_pg17_teardown
+      - os420_pg12_teardown
+      - os420_mysql84_teardown
+      - os420_mysql80_teardown
+      - os420_strimzi047_teardown
+      - os420_keycloak26_teardown
+      - os420_keycloak22_teardown
     if: always()
 
     env:
@@ -1674,7 +1674,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_DEFAULT_REGION: "us-east-1"
-      CLUSTER_NAME: ci419
+      CLUSTER_NAME: ci420
 
     steps:
       - name: Checkout Code
@@ -2152,7 +2152,7 @@ jobs:
     timeout-minutes: 5
     needs:
       - initialize-globals
-      - os419_teardown
+      - os420_teardown
       - os416_teardown
     if: always()
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 /secrets.env
 /workflow-cache/
 /workflow-results/
+/PROJECT_INDEX.json
+/PROJECT_INDEX.md

--- a/README.md
+++ b/README.md
@@ -1,0 +1,378 @@
+# Apicurio Registry Testing Infrastructure
+
+Automated testing infrastructure for validating Apicurio Registry deployments on OpenShift/OKD clusters.
+
+## Overview
+
+This project provides comprehensive end-to-end testing for [Apicurio Registry](https://github.com/Apicurio/apicurio-registry) across multiple configurations, storage backends, and OpenShift versions.
+
+**Test Coverage:**
+- 🔢 **2 OpenShift versions** (4.20, 4.16)
+- 💾 **4 storage backends** (In-memory, PostgreSQL, MySQL, KafkaSQL)
+- 🔐 **Authentication** (Keycloak OAuth2/OIDC)
+- 🧪 **3 test types** (UI, Integration, Security/DAST)
+- ☁️ **AWS-based** cluster provisioning
+
+## Quick Start
+
+### Prerequisites
+
+- AWS account with credentials configured
+- GitHub account with access to this repository
+- Domain with Route53 hosted zone (for TLS certificates)
+
+### 1. Configure Secrets
+
+Create a `secrets.env` file (gitignored):
+
+```bash
+# AWS Configuration
+export AWS_ACCESS_KEY_ID="your-access-key"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
+export AWS_DEFAULT_REGION="us-east-1"
+
+# DNS Configuration
+export BASE_DOMAIN="apicurio-testing.org"
+export HOSTED_ZONE_ID="Z123456789"
+
+# OpenShift Configuration
+export OPENSHIFT_PULL_SECRET='{"auths": {...}}'
+export SSH_PUBLIC_KEY="ssh-rsa ..."
+```
+
+### 2. Load Cache
+
+```bash
+./load-cache.sh --token $GITHUB_TOKEN
+```
+
+This downloads installers, certificates, and cluster configurations from the cache repository.
+
+### 3. Provision Cluster
+
+```bash
+# Provision OpenShift 4.20 cluster with 6 nodes
+./install-cluster.sh --cluster mytest --ocpVersion 4.20
+```
+
+### 4. Deploy Apicurio Registry
+
+```bash
+# Example: PostgreSQL backend
+./install-apicurio-operator.sh --cluster mytest --version 3.1.1
+./install-apicurio-registry.sh --cluster mytest --namespace testns --profile postgresql
+```
+
+### 5. Run Tests
+
+```bash
+# Integration tests
+./run-integration-tests.sh --cluster mytest --namespace testns
+
+# UI tests
+./run-ui-tests.sh --cluster mytest --namespace testns
+
+# Security scan
+./run-dast-scan.sh --cluster mytest --namespace testns
+```
+
+### 6. Cleanup
+
+```bash
+./destroy-cluster.sh --cluster mytest
+./save-cache.sh
+```
+
+## Deployment Profiles
+
+Profiles define complete infrastructure stacks:
+
+| Profile | Storage | Additional Components | Use Case |
+|---------|---------|----------------------|----------|
+| `inmemory` | In-memory | None | Quick testing, ephemeral |
+| `postgresql` | PostgreSQL | PostgreSQL database | Production-like SQL storage |
+| `mysql` | MySQL | MySQL database | MySQL compatibility testing |
+| `kafkasql` | Kafka | Strimzi + Kafka cluster | Distributed storage |
+| `authn` | PostgreSQL | Keycloak | Authentication testing |
+
+**Usage:**
+```bash
+./install-apicurio-registry.sh --cluster mytest --namespace ns1 --profile <profile-name>
+```
+
+## GitHub Actions Workflows
+
+### Main Release Testing
+
+**Workflow:** `.github/workflows/test-registry-release.yaml`
+
+Tests Apicurio Registry releases across the full matrix:
+
+```
+OpenShift 4.20 cluster (ci420)
+├─ inmemory      → UI + Integration + DAST
+├─ PostgreSQL 17 → UI + Integration
+├─ PostgreSQL 12 → Integration (smoke)
+├─ MySQL 8.4     → UI + Integration
+├─ MySQL 8.0     → Integration (smoke)
+├─ KafkaSQL      → UI + Integration
+├─ Keycloak 26   → Integration + DAST
+└─ Keycloak 22   → Integration
+
+OpenShift 4.16 cluster (ci416)
+├─ inmemory      → UI + Integration
+└─ KafkaSQL      → UI + Integration
+```
+
+**Trigger manually:**
+1. Go to Actions → [Test] Registry Release
+2. Click "Run workflow"
+3. Enter release version and test parameters
+
+**Execution time:** ~3.5 hours for full matrix
+
+### Other Workflows
+
+- **test-registry-operator.yaml** - OLM operator testing
+- **infra-provision-cluster.yaml** - Cluster provisioning only
+- **infra-destroy-cluster.yaml** - Cluster destruction
+
+## Project Structure
+
+```
+apicurio-testing/
+├── cache/                  # Git-based cache (installers, certs, kubeconfig)
+├── templates/
+│   ├── ocp/               # OpenShift install-config templates
+│   ├── okd/               # OKD install-config templates
+│   ├── profiles/          # Registry deployment profiles
+│   └── rapidast/          # DAST security scan configs
+├── .github/
+│   ├── workflows/         # GitHub Actions workflows
+│   └── actions/           # Custom actions (commit results, logs)
+├── migration-testing/     # Version 2.x → 3.x migration tests
+├── docs/                  # Additional documentation
+└── *.sh                   # Installation and testing scripts
+```
+
+## Key Scripts
+
+### Cluster Management
+- `install-cluster.sh` - Provision OpenShift cluster on AWS
+- `destroy-cluster.sh` - Destroy cluster and cleanup resources
+- `generate-install-config.sh` - Generate cluster configuration
+
+### Registry Deployment
+- `install-apicurio-operator.sh` - Install Apicurio Registry operator
+- `install-apicurio-registry.sh` - Deploy Registry instance with profile
+- `install-strimzi.sh` - Install Strimzi Kafka operator
+- `install-kafka.sh` - Deploy Kafka cluster
+- `install-keycloak.sh` - Deploy Keycloak for authentication
+
+### Testing
+- `run-integration-tests.sh` - Execute integration test suite
+- `run-ui-tests.sh` - Execute UI/frontend tests
+- `run-dast-scan.sh` - Execute security scanning (RapiDAST)
+
+### Utilities
+- `load-cache.sh` - Clone/pull cache repository
+- `save-cache.sh` - Commit and push cache updates
+- `download-pod-logs.sh` - Collect pod logs for debugging
+
+## Common Use Cases
+
+### Test New Registry Version
+
+```bash
+# 1. Provision cluster
+./install-cluster.sh --cluster test420 --ocpVersion 4.20
+
+# 2. Install operator
+./install-apicurio-operator.sh --cluster test420 --version 3.1.1
+
+# 3. Deploy with PostgreSQL
+./install-apicurio-registry.sh --cluster test420 --namespace pg --profile postgresql
+
+# 4. Run tests
+./run-integration-tests.sh --cluster test420 --namespace pg
+./run-ui-tests.sh --cluster test420 --namespace pg
+
+# 5. Cleanup
+./destroy-cluster.sh --cluster test420
+```
+
+### Test with Keycloak Authentication
+
+```bash
+# Install Keycloak operator and server
+./install-keycloak-operator.sh --cluster test420 --namespace auth
+./install-keycloak.sh --cluster test420 --namespace auth
+
+# Deploy Registry with authentication
+./install-apicurio-registry.sh --cluster test420 --namespace auth --profile authn
+
+# Run auth tests
+./run-integration-tests.sh --cluster test420 --namespace auth --testProfile auth
+```
+
+### Test Migration (v2.6 → v3.1)
+
+```bash
+cd migration-testing/scenario-1
+./scripts/setup.sh
+./scripts/migrate.sh
+./scripts/verify.sh
+```
+
+## Configuration
+
+### Environment Variables (secrets.env)
+
+```bash
+# Required for cluster provisioning
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
+AWS_DEFAULT_REGION
+
+# Required for cluster access
+OPENSHIFT_PULL_SECRET
+SSH_PUBLIC_KEY
+
+# Required for DNS/TLS
+BASE_DOMAIN
+HOSTED_ZONE_ID
+
+# Optional for private registries
+DOCKER_SERVER
+DOCKER_USERNAME
+DOCKER_PASSWORD
+DOCKER_EMAIL
+```
+
+### Cache Directory Structure
+
+The `cache/` directory is a git repository containing:
+
+```
+cache/
+├── bin/                    # OCP/OKD installers
+│   ├── 4.16/
+│   ├── 4.19/
+│   └── 4.20/
+├── certificates/           # Let's Encrypt TLS certificates
+│   ├── ci416/
+│   └── ci420/
+└── clusters/               # Cluster state and kubeconfig
+    ├── ci416/
+    │   └── auth/kubeconfig
+    └── ci420/
+        └── auth/kubeconfig
+```
+
+## Test Results
+
+Test results are automatically committed to a separate repository:
+**apicurio-testing-results**
+
+Results include:
+- Pod logs (on failure)
+- JUnit XML test reports
+- HTML test reports
+- DAST security scan results
+- Workflow metadata and timing
+
+## Troubleshooting
+
+### Cluster provisioning fails
+
+```bash
+# Check AWS credentials
+aws sts get-caller-identity
+
+# Verify installer downloaded
+ls -la cache/bin/4.20/
+
+# Check install logs
+cat cache/clusters/<cluster-name>/.openshift_install.log
+```
+
+### Registry deployment timeout
+
+```bash
+# Check operator logs
+kubectl logs -n <namespace> -l name=apicurio-registry-operator
+
+# Check registry pod status
+kubectl get pods -n <namespace>
+kubectl describe pod -n <namespace> <pod-name>
+```
+
+### Tests fail to connect
+
+```bash
+# Verify route exists
+kubectl get route -n <namespace>
+
+# Test connectivity
+curl -k https://registry-app-<namespace>.apps.<cluster>.<domain>/apis/registry/v3/system/info
+```
+
+### Cache out of sync
+
+```bash
+# Reset cache
+rm -rf cache/
+./load-cache.sh --token $GITHUB_TOKEN
+```
+
+## Cost Considerations
+
+**AWS Resources per cluster:**
+- 3 × m5.xlarge control plane nodes
+- 3 × m5.xlarge compute nodes
+- ELB load balancers
+- Route53 hosted zone
+- S3 storage
+
+**Estimated cost:** ~$1.73/hour per cluster
+
+**Optimization tips:**
+- Reuse clusters with `--skipClusterInstall` flag
+- Use smaller instance types for development
+- Consider spot instances for cost savings
+- Always destroy clusters when done
+
+## Contributing
+
+When adding new test configurations:
+
+1. Create profile in `templates/profiles/<name>/`
+2. Add deployment job to workflow
+3. Add test jobs (UI, integration, DAST as needed)
+4. Add teardown job
+5. Update this README
+
+## Documentation
+
+- **PROJECT_INDEX.md** - Complete project structure and entry points
+- **COMPREHENSIVE_ANALYSIS.md** - Detailed technical analysis
+- **SYSTEM_TESTS_ANALYSIS.md** - System test coverage analysis
+- **docs/Operator-Testing.md** - OLM operator testing guide
+- **docs/Extra-Tests.md** - Additional testing procedures
+- **migration-testing/ANALYSIS.md** - Migration testing guide
+
+## Support
+
+- **Issues:** Report issues in the [GitHub Issues](https://github.com/Apicurio/apicurio-testing/issues)
+- **Discussions:** Use GitHub Discussions for questions
+- **Slack:** #apicurio on CNCF Slack
+
+## License
+
+[Apache License 2.0](LICENSE)
+
+## Related Projects
+
+- [Apicurio Registry](https://github.com/Apicurio/apicurio-registry) - Main Registry repository
+- [Apicurio Registry Operator](https://github.com/Apicurio/apicurio-registry-operator) - Kubernetes operator
+- [Strimzi](https://strimzi.io/) - Kafka on Kubernetes

--- a/install-cluster.sh
+++ b/install-cluster.sh
@@ -89,7 +89,7 @@ usage() {
     echo    "                               Must contain only letters and numbers"
     echo    ""
     echo    "Optional Parameters:"
-    echo    "  --ocpVersion <version>       OCP version to install (default: 4.19)"
+    echo    "  --ocpVersion <version>       OCP version to install (default: 4.20)"
     echo    "  --region <aws-region>        AWS region to deploy to (default: us-east-1)"
     echo    "  --computeNodes <count>       Number of compute/worker nodes (default: 3)"
     echo    "  --controlPlaneNodes <count>  Number of control plane/master nodes (default: 3)"
@@ -102,7 +102,7 @@ usage() {
 
 # Initialize variables
 CLUSTER_NAME="$USER"
-OCP_VERSION="4.19"
+OCP_VERSION="4.20"
 REGION="us-east-1"
 COMPUTE_NODES="3"
 CONTROL_PLANE_NODES="3"

--- a/templates/ocp/4.20/install-config.yaml
+++ b/templates/ocp/4.20/install-config.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+metadata:
+  name: $CLUSTER_NAME
+baseDomain: $BASE_DOMAIN
+controlPlane:
+  architecture: amd64
+  hyperthreading: Enabled
+  name: master
+  replicas: $CONTROL_PLANE_NODES
+  platform:
+    aws:
+      type: m5.xlarge
+      zones:
+        - us-east-1a
+compute:
+  - name: worker
+    replicas: $COMPUTE_NODES
+    platform:
+      aws:
+        type: m5.xlarge
+        zones:
+          - us-east-1a
+platform:
+  aws:
+    region: $REGION
+    userTags:
+      apicurio/Environment: TEST
+      apicurio/ForCleanup: "true"
+      apicurio/FromOcpInstaller: "true"
+      apicurio/cluster: $CLUSTER_NAME
+      app-code: SRQE-001
+      service-phase: dev
+      cost-center: 704
+fips: false
+pullSecret: |
+  $OPENSHIFT_PULL_SECRET
+sshKey: |
+  $SSH_PUBLIC_KEY

--- a/templates/okd/4.20/install-config.yaml
+++ b/templates/okd/4.20/install-config.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+metadata:
+  name: $CLUSTER_NAME
+baseDomain: $BASE_DOMAIN
+controlPlane:
+  name: master
+  replicas: $CONTROL_PLANE_NODES
+  platform:
+    aws:
+      type: m5.xlarge
+      zones:
+        - us-east-1a
+compute:
+  - name: worker
+    replicas: $COMPUTE_NODES
+    platform:
+      aws:
+        type: m5.xlarge
+        zones:
+          - us-east-1a
+platform:
+  aws:
+    region: $REGION
+    userTags:
+      apicurio/Environment: TEST
+      apicurio/ForCleanup: "true"
+      apicurio/FromOkdInstaller: "true"
+      apicurio/cluster: $CLUSTER_NAME
+      app-code: SRQE-001
+      service-phase: dev
+      cost-center: 704
+pullSecret: |
+  $OPENSHIFT_PULL_SECRET
+sshKey: |
+  $SSH_PUBLIC_KEY


### PR DESCRIPTION
## Summary

This PR upgrades the testing infrastructure from OpenShift 4.19 to 4.20 and adds a comprehensive README for the project.

## Changes

### 🔄 OpenShift 4.19 → 4.20 Upgrade

**Template Directories:**
- ✅ Created `templates/ocp/4.20/install-config.yaml`
- ✅ Created `templates/okd/4.20/install-config.yaml`

**GitHub Workflows Updated (5 files):**
1. **test-registry-release.yaml** - Main testing workflow
   - All job names: `os419*` → `os420*`
   - Cluster name: `ci419` → `ci420`
   - Version: `"4.19"` → `"4.20"`
   - **115 changes** across all jobs and dependencies

2. **subtest-registry-operator.yaml** - Default cluster and version updated
3. **infra-provision-cluster.yaml** - Version options and defaults updated
4. **infra-provision-artifact-cluster.yaml** - Cluster version updated
5. **test-registry-operator.yaml** - Example catalog image URIs updated

**Scripts Updated:**
- `install-cluster.sh` - Default OCP version changed to 4.20

### 📚 Documentation

- ✅ Added **README.md** with:
  - Quick start guide (6 steps)
  - Deployment profiles table
  - Common use cases with examples
  - Troubleshooting guide
  - Project structure overview
  - Cost considerations

- ✅ Updated **.gitignore** to exclude generated index files

## Test Coverage

After this upgrade, the **ci420** cluster will test:

| Profile | Storage | Auth | Tests |
|---------|---------|------|-------|
| inmemory | In-memory | None | UI + Integration + DAST |
| pg17 | PostgreSQL 17 | None | UI + Integration |
| pg12 | PostgreSQL 12 | None | Integration (smoke) |
| mysql84 | MySQL 8.4 | None | UI + Integration |
| mysql80 | MySQL 8.0 | None | Integration (smoke) |
| ksql047 | KafkaSQL | None | UI + Integration |
| keycloak26 | PostgreSQL | Keycloak 26 | Integration + DAST |
| keycloak22 | PostgreSQL | Keycloak 22 | Integration |

**OpenShift 4.16 testing remains unchanged** (inmemory + KafkaSQL profiles).

## Impact

- ⚠️ First workflow run will provision a new **ci420** cluster (~90 minutes)
- ⚠️ OCP 4.20 installer will be downloaded and cached
- ✅ No changes to test logic or deployment profiles
- ✅ Backward compatible - can revert easily if needed

## Checklist

- [x] Template directories created for both OCP and OKD
- [x] All workflow files updated and tested for syntax
- [x] Default version updated in shell scripts
- [x] README.md created with comprehensive documentation
- [x] .gitignore updated appropriately
- [ ] First workflow run validated (to be done after merge)

## Related Documentation

- See `UPGRADE_SUMMARY_4.19_to_4.20.md` for detailed upgrade notes (if committed)
- See new `README.md` for project overview and getting started guide

## Rollback Plan

If issues arise, simply revert this PR:
```bash
git revert <merge-commit-hash>
```

Or manually change versions back to 4.19 using sed commands documented in the upgrade summary.