### PR TITLE
Add Kafka Connect converter test infrastructure

### DIFF
--- a/converter-testing/.env
+++ b/converter-testing/.env
@@ -1,0 +1,10 @@
+# Kafka Connect Converter Test Configuration
+
+# Kafka version to test with
+KAFKA_VERSION=3.9.1
+
+# Apicurio Registry version
+APICURIO_VERSION=3.0.7.Final
+
+# Registry image
+REGISTRY_IMAGE=quay.io/apicurio/apicurio-registry:3.0.7.Final

--- a/converter-testing/.env
+++ b/converter-testing/.env
@@ -8,3 +8,6 @@ APICURIO_VERSION=3.0.7.Final
 
 # Registry image
 REGISTRY_IMAGE=quay.io/apicurio/apicurio-registry:3.0.7.Final
+
+# Maven repository URL for downloading the converter artifact
+MAVEN_REPO_URL=https://repo1.maven.org/maven2

--- a/converter-testing/.gitignore
+++ b/converter-testing/.gitignore
@@ -1,0 +1,5 @@
+logs/
+data/*.txt
+data/*.json
+!data/.gitkeep
+clients/*/target/

--- a/converter-testing/README.md
+++ b/converter-testing/README.md
@@ -1,0 +1,172 @@
+# Kafka Connect Converter Test
+
+Test the Apicurio Registry Kafka Connect converter package with supported Kafka versions.
+Verifies serialization/deserialization works correctly for both Avro and ExtJSON converters.
+
+**Test Plan:** [test-kafka-converter.md](https://github.com/Apicurio/rhboar-releases/blob/main/docs/qe/test-kafka-converter.md)
+
+## Overview
+
+This test validates the `apicurio-registry-distro-connect-converter` package, which provides
+Kafka Connect converters for use with Apicurio Registry:
+
+- **AvroConverter** (`io.apicurio.registry.utils.converter.AvroConverter`) - Converts between Kafka Connect's internal format and Avro, storing schemas in Apicurio Registry
+- **ExtJsonConverter** (`io.apicurio.registry.utils.converter.ExtJsonConverter`) - Converts between Kafka Connect's internal format and extended JSON with schema references
+- **SerdeBasedConverter** (`io.apicurio.registry.utils.converter.SerdeBasedConverter`) - Generic converter using configurable serializer/deserializer
+
+## Test Architecture
+
+```
+                          ┌─────────────────┐
+                          │  Apicurio       │
+                          │  Registry       │
+                          │  (port 8080)    │
+                          └────────┬────────┘
+                                   │ schema registration
+                                   │ & lookup
+┌──────────┐    ┌─────────────────┐│┌─────────────────┐    ┌──────────┐
+│  Source   │───▶│ Kafka Connect   │││ Kafka Connect   │───▶│  Sink    │
+│  File     │    │ Source Connector│││ Sink Connector  │    │  File    │
+└──────────┘    │ (Avro Converter)│││ (Avro Converter)│    └──────────┘
+                └────────┬────────┘│└────────┬────────┘
+                         │         │         │
+                         ▼         │         ▼
+                    ┌──────────────────────────────┐
+                    │         Apache Kafka          │
+                    │         (port 9092)           │
+                    └──────────────────────────────┘
+```
+
+## Quick Start
+
+```bash
+# Run the full test with defaults
+./run-converter-test.sh
+
+# Run interactively (pause between steps)
+./run-converter-test.sh --interactive
+
+# Test with specific Kafka version
+./run-converter-test.sh --kafka-version 3.8.1
+
+# Test with specific Apicurio version
+./run-converter-test.sh --apicurio-version 3.0.7.Final
+
+# Skip the Java test client
+./run-converter-test.sh --skip-java-test
+
+# Clean up after testing
+./scripts/cleanup.sh --remove-volumes --remove-data
+```
+
+## Test Steps
+
+| Step | Description | Script |
+|------|-------------|--------|
+| A | Deploy Apache Kafka (KRaft mode) | `scripts/step-A-deploy-kafka.sh` |
+| B | Deploy Apicurio Registry (in-memory) | `scripts/step-B-deploy-registry.sh` |
+| C | Build & deploy Kafka Connect with Apicurio converter | `scripts/step-C-deploy-connect.sh` |
+| D | Test Avro converter (source + sink connectors) | `scripts/step-D-test-avro-converter.sh` |
+| E | Test ExtJSON converter (source + sink connectors) | `scripts/step-E-test-json-converter.sh` |
+| F | Verify schemas registered in Apicurio Registry | `scripts/step-F-verify-schemas.sh` |
+| G | Run Java converter test client (direct API test) | `scripts/build-and-run-client.sh` |
+
+## Supported Kafka Versions
+
+The test can be run against different Kafka versions by passing `--kafka-version`:
+
+| Kafka Version | Image Tag | Status |
+|---------------|-----------|--------|
+| 3.9.1 | `apache/kafka:3.9.1` | Default |
+| 3.8.1 | `apache/kafka:3.8.1` | Supported |
+| 3.7.2 | `apache/kafka:3.7.2` | Supported |
+
+## Configuration
+
+Edit `.env` to change default versions:
+
+```env
+KAFKA_VERSION=3.9.1
+APICURIO_VERSION=3.0.7.Final
+REGISTRY_IMAGE=quay.io/apicurio/apicurio-registry:3.0.7.Final
+```
+
+## Directory Structure
+
+```
+converter-testing/
+├── README.md                          # This file
+├── .env                               # Version configuration
+├── run-converter-test.sh              # Main test orchestration
+├── docker-compose-kafka.yml           # Kafka broker (KRaft mode)
+├── docker-compose-registry.yml        # Apicurio Registry (in-memory)
+├── docker-compose-connect.yml         # Kafka Connect with converter
+├── connect/
+│   ├── Dockerfile                     # Custom Connect image with converter
+│   └── start-connect.sh              # Connect worker startup script
+├── connectors/
+│   ├── avro-file-source.json         # Avro source connector config
+│   ├── avro-file-sink.json           # Avro sink connector config
+│   ├── json-file-source.json         # ExtJSON source connector config
+│   └── json-file-sink.json           # ExtJSON sink connector config
+├── clients/
+│   └── converter-test/               # Java converter test client
+│       ├── pom.xml
+│       └── src/main/java/...
+├── scripts/
+│   ├── step-A-deploy-kafka.sh
+│   ├── step-B-deploy-registry.sh
+│   ├── step-C-deploy-connect.sh
+│   ├── step-D-test-avro-converter.sh
+│   ├── step-E-test-json-converter.sh
+│   ├── step-F-verify-schemas.sh
+│   ├── build-and-run-client.sh
+│   └── cleanup.sh
+├── data/                              # Test data (generated)
+└── logs/                              # Test logs (generated)
+```
+
+## Java Converter Test Client
+
+The Java test client (`clients/converter-test/`) directly tests the converter API
+without needing Kafka Connect. It validates:
+
+1. **AvroConverter** - Simple struct serialization/deserialization roundtrip
+2. **AvroConverter** - Default values and optional fields
+3. **ExtJsonConverter** - Simple struct roundtrip
+4. **SerdeBasedConverter** - Explicit serializer/deserializer configuration
+5. **AvroConverter** - Null payload handling
+
+### Building and running independently:
+
+```bash
+cd clients/converter-test
+mvn clean package -DskipTests
+REGISTRY_URL=http://localhost:8080/apis/registry/v3 java -jar target/converter-test-1.0.0-SNAPSHOT.jar
+```
+
+## Prerequisites
+
+- Docker and Docker Compose
+- Java 17+ and Maven (for the Java test client)
+- `curl` and `jq` (for the shell scripts)
+
+## Troubleshooting
+
+### Kafka Connect won't start
+Check the converter download in the Dockerfile build:
+```bash
+docker logs converter-connect
+```
+
+### Connector tasks fail
+Check the connector status:
+```bash
+curl -s http://localhost:8083/connectors/avro-file-source/status | jq
+```
+
+### No schemas in registry
+Verify the registry URL in connector config matches the running registry:
+```bash
+curl -s http://localhost:8080/apis/registry/v3/search/artifacts | jq
+```

--- a/converter-testing/clients/converter-test/pom.xml
+++ b/converter-testing/clients/converter-test/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.apicurio.testing</groupId>
+    <artifactId>converter-test</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Kafka Connect Converter Test</name>
+    <description>Tests Apicurio Registry Kafka Connect converters (AvroConverter, ExtJsonConverter)</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <apicurio-registry.version>3.0.7.Final</apicurio-registry.version>
+        <kafka.version>3.9.1</kafka.version>
+        <slf4j.version>1.7.36</slf4j.version>
+    </properties>
+
+    <dependencies>
+        <!-- Apicurio Registry Converter -->
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-utils-converter</artifactId>
+            <version>${apicurio-registry.version}</version>
+        </dependency>
+
+        <!-- Apicurio Registry Avro SerDe (required by converter) -->
+        <dependency>
+            <groupId>io.apicurio</groupId>
+            <artifactId>apicurio-registry-avro-serde-kafka</artifactId>
+            <version>${apicurio-registry.version}</version>
+        </dependency>
+
+        <!-- Kafka Connect API -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-json</artifactId>
+            <version>${kafka.version}</version>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals><goal>shade</goal></goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>io.apicurio.testing.converter.ConverterTestApp</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/converter-testing/clients/converter-test/src/main/java/io/apicurio/testing/converter/ConverterTestApp.java
+++ b/converter-testing/clients/converter-test/src/main/java/io/apicurio/testing/converter/ConverterTestApp.java
@@ -1,0 +1,285 @@
+package io.apicurio.testing.converter;
+
+import io.apicurio.registry.serde.avro.AvroKafkaDeserializer;
+import io.apicurio.registry.serde.avro.AvroKafkaSerializer;
+import io.apicurio.registry.serde.avro.AvroSerdeConfig;
+import io.apicurio.registry.serde.avro.DefaultAvroDatumProvider;
+import io.apicurio.registry.serde.config.SerdeConfig;
+import io.apicurio.registry.utils.converter.AvroConverter;
+import io.apicurio.registry.utils.converter.ExtJsonConverter;
+import io.apicurio.registry.utils.converter.SerdeBasedConverter;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Standalone test application for Apicurio Registry Kafka Connect converters.
+ *
+ * Tests:
+ * 1. AvroConverter - serialization/deserialization roundtrip
+ * 2. ExtJsonConverter - serialization/deserialization roundtrip
+ * 3. SerdeBasedConverter - manual serde configuration
+ * 4. Schema registration verification
+ */
+public class ConverterTestApp {
+
+    private static final String DEFAULT_REGISTRY_URL = "http://localhost:8080/apis/registry/v3";
+
+    private static int testsPassed = 0;
+    private static int testsFailed = 0;
+
+    public static void main(String[] args) {
+        String registryUrl = System.getenv().getOrDefault("REGISTRY_URL", DEFAULT_REGISTRY_URL);
+
+        System.out.println("=========================================");
+        System.out.println("  Kafka Connect Converter Test");
+        System.out.println("=========================================");
+        System.out.println("Registry URL: " + registryUrl);
+        System.out.println("=========================================");
+        System.out.println();
+
+        // Run all tests
+        testAvroConverterSimpleStruct(registryUrl);
+        testAvroConverterWithDefaults(registryUrl);
+        testExtJsonConverterSimpleStruct(registryUrl);
+        testSerdeBasedConverter(registryUrl);
+        testAvroConverterNullHandling(registryUrl);
+
+        // Summary
+        System.out.println();
+        System.out.println("=========================================");
+        System.out.println("  TEST RESULTS");
+        System.out.println("=========================================");
+        System.out.println("  Passed: " + testsPassed);
+        System.out.println("  Failed: " + testsFailed);
+        System.out.println("  Total:  " + (testsPassed + testsFailed));
+        System.out.println("=========================================");
+
+        if (testsFailed > 0) {
+            System.out.println("OVERALL: FAILED");
+            System.exit(1);
+        } else {
+            System.out.println("OVERALL: PASSED");
+        }
+    }
+
+    /**
+     * Test 1: AvroConverter with a simple struct (string field)
+     */
+    private static void testAvroConverterSimpleStruct(String registryUrl) {
+        String testName = "AvroConverter - Simple Struct";
+        System.out.println("--- Test: " + testName + " ---");
+
+        try (AvroConverter converter = new AvroConverter()) {
+            Map<String, Object> config = new HashMap<>();
+            config.put(SerdeConfig.REGISTRY_URL, registryUrl);
+            config.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
+            converter.configure(config, false);
+
+            // Create a simple struct schema
+            Schema schema = SchemaBuilder.struct()
+                    .field("name", Schema.STRING_SCHEMA)
+                    .field("value", Schema.STRING_SCHEMA)
+                    .build();
+
+            Struct original = new Struct(schema);
+            original.put("name", "test-key");
+            original.put("value", "test-value");
+
+            String topic = "converter_test_avro_simple";
+
+            // Serialize (fromConnectData)
+            byte[] serialized = converter.fromConnectData(topic, schema, original);
+            assertNotNull(serialized, "Serialized bytes should not be null");
+            assertTrue(serialized.length > 0, "Serialized bytes should not be empty");
+
+            // Deserialize (toConnectData)
+            SchemaAndValue result = converter.toConnectData(topic, serialized);
+            assertNotNull(result, "Deserialized result should not be null");
+            assertNotNull(result.value(), "Deserialized value should not be null");
+
+            Struct deserialized = (Struct) result.value();
+            assertEquals("test-key", deserialized.get("name").toString(), "Name field");
+            assertEquals("test-value", deserialized.get("value").toString(), "Value field");
+
+            pass(testName);
+        } catch (Exception e) {
+            fail(testName, e);
+        }
+    }
+
+    /**
+     * Test 2: AvroConverter with default values and optional fields
+     */
+    private static void testAvroConverterWithDefaults(String registryUrl) {
+        String testName = "AvroConverter - Defaults and Optional Fields";
+        System.out.println("--- Test: " + testName + " ---");
+
+        try (AvroConverter converter = new AvroConverter()) {
+            Map<String, Object> config = new HashMap<>();
+            config.put(SerdeConfig.REGISTRY_URL, registryUrl);
+            config.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
+            converter.configure(config, false);
+
+            Schema schema = SchemaBuilder.struct()
+                    .field("id", Schema.INT32_SCHEMA)
+                    .field("description", SchemaBuilder.string().optional().defaultValue("no description").build())
+                    .build();
+
+            Struct original = new Struct(schema);
+            original.put("id", 42);
+            original.put("description", "test description");
+
+            String topic = "converter_test_avro_defaults";
+
+            byte[] serialized = converter.fromConnectData(topic, schema, original);
+            SchemaAndValue result = converter.toConnectData(topic, serialized);
+
+            Struct deserialized = (Struct) result.value();
+            assertEquals(42, (int) deserialized.getInt32("id"), "ID field");
+            assertEquals("test description", deserialized.get("description").toString(), "Description field");
+
+            pass(testName);
+        } catch (Exception e) {
+            fail(testName, e);
+        }
+    }
+
+    /**
+     * Test 3: ExtJsonConverter with a simple struct
+     */
+    private static void testExtJsonConverterSimpleStruct(String registryUrl) {
+        String testName = "ExtJsonConverter - Simple Struct";
+        System.out.println("--- Test: " + testName + " ---");
+
+        try (ExtJsonConverter converter = new ExtJsonConverter()) {
+            Map<String, Object> config = new HashMap<>();
+            config.put(SerdeConfig.REGISTRY_URL, registryUrl);
+            config.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
+            converter.configure(config, false);
+
+            Schema schema = SchemaBuilder.struct()
+                    .field("message", Schema.STRING_SCHEMA)
+                    .build();
+
+            Struct original = new Struct(schema);
+            original.put("message", "hello from ExtJson converter");
+
+            String topic = "converter_test_extjson";
+
+            byte[] serialized = converter.fromConnectData(topic, schema, original);
+            assertNotNull(serialized, "Serialized bytes should not be null");
+
+            SchemaAndValue result = converter.toConnectData(topic, serialized);
+            assertNotNull(result, "Deserialized result should not be null");
+
+            Struct deserialized = (Struct) result.value();
+            assertEquals("hello from ExtJson converter", deserialized.get("message").toString(), "Message field");
+
+            pass(testName);
+        } catch (Exception e) {
+            fail(testName, e);
+        }
+    }
+
+    /**
+     * Test 4: SerdeBasedConverter with explicit serializer/deserializer
+     */
+    private static void testSerdeBasedConverter(String registryUrl) {
+        String testName = "SerdeBasedConverter - Explicit SerDe Config";
+        System.out.println("--- Test: " + testName + " ---");
+
+        try (SerdeBasedConverter converter = new SerdeBasedConverter()) {
+            Map<String, Object> config = new HashMap<>();
+            config.put(SerdeConfig.REGISTRY_URL, registryUrl);
+            config.put(SerdeConfig.AUTO_REGISTER_ARTIFACT, "true");
+            config.put(SerdeBasedConverter.REGISTRY_CONVERTER_SERIALIZER_PARAM,
+                    AvroKafkaSerializer.class.getName());
+            config.put(SerdeBasedConverter.REGISTRY_CONVERTER_DESERIALIZER_PARAM,
+                    AvroKafkaDeserializer.class.getName());
+            config.put(AvroSerdeConfig.AVRO_DATUM_PROVIDER, DefaultAvroDatumProvider.class.getName());
+            converter.configure(config, false);
+
+            Schema schema = SchemaBuilder.struct()
+                    .field("key", Schema.STRING_SCHEMA)
+                    .field("count", Schema.INT32_SCHEMA)
+                    .build();
+
+            Struct original = new Struct(schema);
+            original.put("key", "serde-test");
+            original.put("count", 99);
+
+            String topic = "converter_test_serde_based";
+
+            byte[] serialized = converter.fromConnectData(topic, schema, original);
+            assertNotNull(serialized, "Serialized bytes should not be null");
+
+            SchemaAndValue result = converter.toConnectData(topic, serialized);
+            assertNotNull(result, "Deserialized result should not be null");
+
+            pass(testName);
+        } catch (Exception e) {
+            fail(testName, e);
+        }
+    }
+
+    /**
+     * Test 5: AvroConverter null payload handling
+     */
+    private static void testAvroConverterNullHandling(String registryUrl) {
+        String testName = "AvroConverter - Null Payload";
+        System.out.println("--- Test: " + testName + " ---");
+
+        try (AvroConverter converter = new AvroConverter()) {
+            Map<String, Object> config = new HashMap<>();
+            config.put(SerdeConfig.REGISTRY_URL, registryUrl);
+            converter.configure(config, false);
+
+            SchemaAndValue result = converter.toConnectData("test-null-topic", null);
+            assertNotNull(result, "Result should not be null for null input");
+
+            pass(testName);
+        } catch (Exception e) {
+            fail(testName, e);
+        }
+    }
+
+    // --- Assertion helpers ---
+
+    private static void assertNotNull(Object value, String message) {
+        if (value == null) {
+            throw new AssertionError("Assertion failed: " + message + " (expected non-null, got null)");
+        }
+    }
+
+    private static void assertTrue(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError("Assertion failed: " + message);
+        }
+    }
+
+    private static void assertEquals(Object expected, Object actual, String fieldName) {
+        if (!expected.equals(actual)) {
+            throw new AssertionError("Assertion failed for " + fieldName +
+                    ": expected '" + expected + "', got '" + actual + "'");
+        }
+    }
+
+    private static void pass(String testName) {
+        testsPassed++;
+        System.out.println("  PASSED: " + testName);
+        System.out.println();
+    }
+
+    private static void fail(String testName, Exception e) {
+        testsFailed++;
+        System.out.println("  FAILED: " + testName);
+        System.out.println("  Error: " + e.getMessage());
+        e.printStackTrace(System.out);
+        System.out.println();
+    }
+}

--- a/converter-testing/connect/Dockerfile
+++ b/converter-testing/connect/Dockerfile
@@ -1,0 +1,38 @@
+## Stage 1: Download the Apicurio Registry converter distribution
+FROM eclipse-temurin:17-jre AS downloader
+
+ARG APICURIO_VERSION=3.0.7.Final
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /converter && \
+    cd /tmp && \
+    echo "Downloading Apicurio Registry Connect Converter v${APICURIO_VERSION}..." && \
+    curl -L -f -o converter.tar.gz \
+      "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-distro-connect-converter/${APICURIO_VERSION}/apicurio-registry-distro-connect-converter-${APICURIO_VERSION}-converter.tar.gz" && \
+    tar -xzf converter.tar.gz -C /converter && \
+    rm converter.tar.gz && \
+    echo "Converter contents:" && \
+    ls -la /converter/
+
+## Stage 2: Build the Kafka Connect image with the converter plugin
+ARG KAFKA_VERSION=3.9.1
+FROM apache/kafka:${KAFKA_VERSION}
+
+USER root
+
+# Copy the converter JARs from the downloader stage
+COPY --from=downloader /converter /opt/kafka/connect-plugins/apicurio-converter
+
+# Copy custom entrypoint that starts Connect in distributed mode
+COPY start-connect.sh /opt/kafka/start-connect.sh
+RUN chmod +x /opt/kafka/start-connect.sh
+
+RUN echo "Apicurio converter plugin installed:" && \
+    ls -la /opt/kafka/connect-plugins/apicurio-converter/
+
+USER appuser
+
+EXPOSE 8083
+
+CMD ["/opt/kafka/start-connect.sh"]

--- a/converter-testing/connect/Dockerfile
+++ b/converter-testing/connect/Dockerfile
@@ -2,14 +2,15 @@
 FROM eclipse-temurin:17-jre AS downloader
 
 ARG APICURIO_VERSION=3.0.7.Final
+ARG MAVEN_REPO_URL=https://repo1.maven.org/maven2
 
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /converter && \
     cd /tmp && \
-    echo "Downloading Apicurio Registry Connect Converter v${APICURIO_VERSION}..." && \
+    echo "Downloading Apicurio Registry Connect Converter v${APICURIO_VERSION} from ${MAVEN_REPO_URL}..." && \
     curl -L -f -o converter.tar.gz \
-      "https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-distro-connect-converter/${APICURIO_VERSION}/apicurio-registry-distro-connect-converter-${APICURIO_VERSION}-converter.tar.gz" && \
+      "${MAVEN_REPO_URL}/io/apicurio/apicurio-registry-distro-connect-converter/${APICURIO_VERSION}/apicurio-registry-distro-connect-converter-${APICURIO_VERSION}-converter.tar.gz" && \
     tar -xzf converter.tar.gz -C /converter && \
     rm converter.tar.gz && \
     echo "Converter contents:" && \

--- a/converter-testing/connect/start-connect.sh
+++ b/converter-testing/connect/start-connect.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Start Kafka Connect in distributed mode with configuration from environment variables
+
+set -e
+
+CONNECT_PROPS="/tmp/connect-distributed.properties"
+
+# Generate connect-distributed.properties from environment variables
+cat > "$CONNECT_PROPS" <<EOF
+# Kafka Connect Distributed Worker Configuration
+bootstrap.servers=${KAFKA_CONNECT_BOOTSTRAP_SERVERS:-localhost:9092}
+group.id=${KAFKA_CONNECT_GROUP_ID:-converter-test-group}
+
+# Internal topic configuration
+config.storage.topic=${KAFKA_CONNECT_CONFIG_STORAGE_TOPIC:-connect-configs}
+offset.storage.topic=${KAFKA_CONNECT_OFFSET_STORAGE_TOPIC:-connect-offsets}
+status.storage.topic=${KAFKA_CONNECT_STATUS_STORAGE_TOPIC:-connect-status}
+config.storage.replication.factor=${KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR:-1}
+offset.storage.replication.factor=${KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR:-1}
+status.storage.replication.factor=${KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR:-1}
+
+# Default converters
+key.converter=${KAFKA_CONNECT_KEY_CONVERTER:-org.apache.kafka.connect.storage.StringConverter}
+value.converter=${KAFKA_CONNECT_VALUE_CONVERTER:-org.apache.kafka.connect.storage.StringConverter}
+
+# Plugin path
+plugin.path=${KAFKA_CONNECT_PLUGIN_PATH:-/opt/kafka/connect-plugins}
+
+# REST API
+rest.advertised.host.name=${KAFKA_CONNECT_REST_ADVERTISED_HOST_NAME:-connect}
+rest.port=8083
+
+# Offset flush interval
+offset.flush.interval.ms=10000
+EOF
+
+echo "Starting Kafka Connect with configuration:"
+echo "============================================"
+cat "$CONNECT_PROPS"
+echo "============================================"
+
+exec /opt/kafka/bin/connect-distributed.sh "$CONNECT_PROPS"

--- a/converter-testing/connectors/avro-file-sink.json
+++ b/converter-testing/connectors/avro-file-sink.json
@@ -1,0 +1,12 @@
+{
+  "name": "avro-file-sink",
+  "config": {
+    "connector.class": "org.apache.kafka.connect.file.FileStreamSinkConnector",
+    "tasks.max": "1",
+    "topics": "avro-converter-test",
+    "file": "/data/avro-sink-output.txt",
+    "value.converter": "io.apicurio.registry.utils.converter.AvroConverter",
+    "value.converter.apicurio.registry.url": "http://registry:8080/apis/registry/v3",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter"
+  }
+}

--- a/converter-testing/connectors/avro-file-source.json
+++ b/converter-testing/connectors/avro-file-source.json
@@ -1,0 +1,13 @@
+{
+  "name": "avro-file-source",
+  "config": {
+    "connector.class": "org.apache.kafka.connect.file.FileStreamSourceConnector",
+    "tasks.max": "1",
+    "topic": "avro-converter-test",
+    "file": "/data/avro-source-input.txt",
+    "value.converter": "io.apicurio.registry.utils.converter.AvroConverter",
+    "value.converter.apicurio.registry.url": "http://registry:8080/apis/registry/v3",
+    "value.converter.apicurio.registry.auto-register": "true",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter"
+  }
+}

--- a/converter-testing/connectors/json-file-sink.json
+++ b/converter-testing/connectors/json-file-sink.json
@@ -1,0 +1,12 @@
+{
+  "name": "json-file-sink",
+  "config": {
+    "connector.class": "org.apache.kafka.connect.file.FileStreamSinkConnector",
+    "tasks.max": "1",
+    "topics": "json-converter-test",
+    "file": "/data/json-sink-output.txt",
+    "value.converter": "io.apicurio.registry.utils.converter.ExtJsonConverter",
+    "value.converter.apicurio.registry.url": "http://registry:8080/apis/registry/v3",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter"
+  }
+}

--- a/converter-testing/connectors/json-file-source.json
+++ b/converter-testing/connectors/json-file-source.json
@@ -1,0 +1,13 @@
+{
+  "name": "json-file-source",
+  "config": {
+    "connector.class": "org.apache.kafka.connect.file.FileStreamSourceConnector",
+    "tasks.max": "1",
+    "topic": "json-converter-test",
+    "file": "/data/json-source-input.txt",
+    "value.converter": "io.apicurio.registry.utils.converter.ExtJsonConverter",
+    "value.converter.apicurio.registry.url": "http://registry:8080/apis/registry/v3",
+    "value.converter.apicurio.registry.auto-register": "true",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter"
+  }
+}

--- a/converter-testing/docker-compose-connect.yml
+++ b/converter-testing/docker-compose-connect.yml
@@ -1,0 +1,45 @@
+services:
+  connect:
+    build:
+      context: ./connect
+      args:
+        KAFKA_VERSION: ${KAFKA_VERSION:-3.9.1}
+        APICURIO_VERSION: ${APICURIO_VERSION:-3.0.7.Final}
+    container_name: converter-connect
+    hostname: connect
+    ports:
+      - "8083:8083"
+    environment:
+      # Kafka Connect distributed worker configuration
+      KAFKA_CONNECT_BOOTSTRAP_SERVERS: "converter-kafka:29092"
+      KAFKA_CONNECT_GROUP_ID: "converter-test-group"
+      KAFKA_CONNECT_CONFIG_STORAGE_TOPIC: "connect-configs"
+      KAFKA_CONNECT_OFFSET_STORAGE_TOPIC: "connect-offsets"
+      KAFKA_CONNECT_STATUS_STORAGE_TOPIC: "connect-status"
+      KAFKA_CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR: 1
+      KAFKA_CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR: 1
+      KAFKA_CONNECT_STATUS_STORAGE_REPLICATION_FACTOR: 1
+      KAFKA_CONNECT_KEY_CONVERTER: "org.apache.kafka.connect.storage.StringConverter"
+      KAFKA_CONNECT_VALUE_CONVERTER: "org.apache.kafka.connect.storage.StringConverter"
+      KAFKA_CONNECT_PLUGIN_PATH: "/opt/kafka/connect-plugins"
+      KAFKA_CONNECT_REST_ADVERTISED_HOST_NAME: "connect"
+    volumes:
+      - connect-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8083/ || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
+    networks:
+      - converter-network
+    restart: unless-stopped
+
+volumes:
+  connect-data:
+    name: converter-connect-data
+
+networks:
+  converter-network:
+    name: converter-test-network
+    external: true

--- a/converter-testing/docker-compose-connect.yml
+++ b/converter-testing/docker-compose-connect.yml
@@ -5,6 +5,7 @@ services:
       args:
         KAFKA_VERSION: ${KAFKA_VERSION:-3.9.1}
         APICURIO_VERSION: ${APICURIO_VERSION:-3.0.7.Final}
+        MAVEN_REPO_URL: ${MAVEN_REPO_URL:-https://repo1.maven.org/maven2}
     container_name: converter-connect
     hostname: connect
     ports:

--- a/converter-testing/docker-compose-kafka.yml
+++ b/converter-testing/docker-compose-kafka.yml
@@ -1,0 +1,43 @@
+services:
+  kafka:
+    image: apache/kafka:${KAFKA_VERSION:-3.9.1}
+    container_name: converter-kafka
+    hostname: kafka
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+    environment:
+      CLUSTER_ID: 'Q29udmVydGVyVGVzdENsdXN0'
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@converter-kafka:9093'
+      KAFKA_LISTENERS: 'PLAINTEXT://converter-kafka:29092,CONTROLLER://converter-kafka:9093,PLAINTEXT_HOST://0.0.0.0:9092'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://converter-kafka:29092,PLAINTEXT_HOST://localhost:9092'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+      KAFKA_NUM_PARTITIONS: 1
+      KAFKA_DEFAULT_REPLICATION_FACTOR: 1
+      KAFKA_LOG_RETENTION_HOURS: 168
+      KAFKA_LOG_RETENTION_BYTES: 1073741824
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      KAFKA_LOG4J_ROOT_LOGLEVEL: INFO
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    networks:
+      - converter-network
+    restart: unless-stopped
+
+networks:
+  converter-network:
+    name: converter-test-network
+    driver: bridge

--- a/converter-testing/docker-compose-registry.yml
+++ b/converter-testing/docker-compose-registry.yml
@@ -1,0 +1,24 @@
+services:
+  registry:
+    image: ${REGISTRY_IMAGE:-quay.io/apicurio/apicurio-registry:3.0.7.Final}
+    container_name: converter-registry
+    hostname: registry
+    ports:
+      - "8080:8080"
+    environment:
+      APICURIO_STORAGE_KIND: "sql"
+      APICURIO_STORAGE_SQL_KIND: "h2"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health/ready || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+    networks:
+      - converter-network
+    restart: unless-stopped
+
+networks:
+  converter-network:
+    name: converter-test-network
+    external: true

--- a/converter-testing/run-converter-test.sh
+++ b/converter-testing/run-converter-test.sh
@@ -1,0 +1,275 @@
+#!/bin/bash
+
+# Run All Steps - Kafka Connect Converter Test
+#
+# This script runs all test steps in sequence to validate the
+# Apicurio Registry Kafka Connect converter package.
+#
+# Usage:
+#   ./run-converter-test.sh                              # Run with defaults
+#   ./run-converter-test.sh --interactive                # Pause between steps
+#   ./run-converter-test.sh --kafka-version 3.8.1        # Test specific Kafka version
+#   ./run-converter-test.sh --apicurio-version 3.0.7.Final  # Test specific Registry version
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="$SCRIPT_DIR/scripts"
+LOG_DIR="$SCRIPT_DIR/logs"
+
+mkdir -p "$LOG_DIR"
+
+MASTER_LOG="$LOG_DIR/run-converter-test.log"
+
+log() {
+    echo "$1" | tee -a "$MASTER_LOG"
+}
+
+# Parse arguments
+PAUSE_BETWEEN_STEPS=false
+KAFKA_VERSION=""
+APICURIO_VERSION=""
+REGISTRY_IMAGE=""
+SKIP_JAVA_TEST=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --interactive)
+            PAUSE_BETWEEN_STEPS=true
+            shift
+            ;;
+        --kafka-version)
+            KAFKA_VERSION="$2"
+            shift 2
+            ;;
+        --apicurio-version)
+            APICURIO_VERSION="$2"
+            shift 2
+            ;;
+        --registry-image)
+            REGISTRY_IMAGE="$2"
+            shift 2
+            ;;
+        --skip-java-test)
+            SKIP_JAVA_TEST=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--interactive] [--kafka-version VERSION] [--apicurio-version VERSION] [--registry-image IMAGE] [--skip-java-test]"
+            exit 1
+            ;;
+    esac
+done
+
+# Update .env file if custom versions are specified
+ENV_FILE="$SCRIPT_DIR/.env"
+if [ -n "$KAFKA_VERSION" ]; then
+    sed -i.bak "s/^KAFKA_VERSION=.*/KAFKA_VERSION=$KAFKA_VERSION/" "$ENV_FILE"
+    rm -f "$ENV_FILE.bak"
+    log "Using Kafka version: $KAFKA_VERSION"
+fi
+if [ -n "$APICURIO_VERSION" ]; then
+    sed -i.bak "s/^APICURIO_VERSION=.*/APICURIO_VERSION=$APICURIO_VERSION/" "$ENV_FILE"
+    rm -f "$ENV_FILE.bak"
+    log "Using Apicurio version: $APICURIO_VERSION"
+fi
+if [ -n "$REGISTRY_IMAGE" ]; then
+    sed -i.bak "s|^REGISTRY_IMAGE=.*|REGISTRY_IMAGE=$REGISTRY_IMAGE|" "$ENV_FILE"
+    rm -f "$ENV_FILE.bak"
+    log "Using Registry image: $REGISTRY_IMAGE"
+fi
+
+# Read current versions from .env
+source "$ENV_FILE"
+
+pause_step() {
+    if [ "$PAUSE_BETWEEN_STEPS" = true ]; then
+        log ""
+        log "Press Enter to continue to next step..."
+        read -r
+    else
+        sleep 2
+    fi
+}
+
+log "================================================================"
+log "  Kafka Connect Converter Test"
+log "  Apicurio Registry Converter Package Validation"
+log "================================================================"
+log ""
+log "Configuration:"
+log "  Kafka Version: ${KAFKA_VERSION:-default}"
+log "  Apicurio Version: ${APICURIO_VERSION:-default}"
+log "  Registry Image: ${REGISTRY_IMAGE:-default}"
+log ""
+log "Test Steps:"
+log "  A. Deploy Kafka"
+log "  B. Deploy Apicurio Registry"
+log "  C. Deploy Kafka Connect (with Apicurio converter)"
+log "  D. Test Avro Converter"
+log "  E. Test ExtJSON Converter"
+log "  F. Verify Schemas in Registry"
+if [ "$SKIP_JAVA_TEST" = false ]; then
+    log "  G. Run Java Converter Test Client"
+fi
+log ""
+log "Master log: $MASTER_LOG"
+log ""
+
+if [ "$PAUSE_BETWEEN_STEPS" = true ]; then
+    log "Press Enter to start..."
+    read -r
+else
+    log "Running in automatic mode"
+    sleep 2
+fi
+
+# Track test results
+STEP_RESULTS=()
+record_result() {
+    STEP_RESULTS+=("$1")
+}
+
+# Step A: Deploy Kafka
+log ""
+log "================================================================"
+log "  STEP A: Deploy Kafka"
+log "================================================================"
+if "$SCRIPTS_DIR/step-A-deploy-kafka.sh" 2>&1 | tee -a "$MASTER_LOG"; then
+    record_result "A-Deploy-Kafka: PASSED"
+else
+    record_result "A-Deploy-Kafka: FAILED"
+    log "FATAL: Kafka deployment failed. Aborting."
+    exit 1
+fi
+pause_step
+
+# Step B: Deploy Registry
+log ""
+log "================================================================"
+log "  STEP B: Deploy Apicurio Registry"
+log "================================================================"
+if "$SCRIPTS_DIR/step-B-deploy-registry.sh" 2>&1 | tee -a "$MASTER_LOG"; then
+    record_result "B-Deploy-Registry: PASSED"
+else
+    record_result "B-Deploy-Registry: FAILED"
+    log "FATAL: Registry deployment failed. Aborting."
+    exit 1
+fi
+pause_step
+
+# Step C: Deploy Kafka Connect
+log ""
+log "================================================================"
+log "  STEP C: Deploy Kafka Connect"
+log "================================================================"
+if "$SCRIPTS_DIR/step-C-deploy-connect.sh" 2>&1 | tee -a "$MASTER_LOG"; then
+    record_result "C-Deploy-Connect: PASSED"
+else
+    record_result "C-Deploy-Connect: FAILED"
+    log "FATAL: Kafka Connect deployment failed. Aborting."
+    exit 1
+fi
+pause_step
+
+# Step D: Test Avro Converter
+log ""
+log "================================================================"
+log "  STEP D: Test Avro Converter"
+log "================================================================"
+if "$SCRIPTS_DIR/step-D-test-avro-converter.sh" 2>&1 | tee -a "$MASTER_LOG"; then
+    record_result "D-Avro-Converter: PASSED"
+else
+    record_result "D-Avro-Converter: FAILED"
+fi
+pause_step
+
+# Step E: Test ExtJSON Converter
+log ""
+log "================================================================"
+log "  STEP E: Test ExtJSON Converter"
+log "================================================================"
+if "$SCRIPTS_DIR/step-E-test-json-converter.sh" 2>&1 | tee -a "$MASTER_LOG"; then
+    record_result "E-ExtJSON-Converter: PASSED"
+else
+    record_result "E-ExtJSON-Converter: FAILED"
+fi
+pause_step
+
+# Step F: Verify Schemas
+log ""
+log "================================================================"
+log "  STEP F: Verify Schemas in Registry"
+log "================================================================"
+if "$SCRIPTS_DIR/step-F-verify-schemas.sh" 2>&1 | tee -a "$MASTER_LOG"; then
+    record_result "F-Verify-Schemas: PASSED"
+else
+    record_result "F-Verify-Schemas: FAILED"
+fi
+pause_step
+
+# Step G: Java Converter Test (optional)
+if [ "$SKIP_JAVA_TEST" = false ] && [ -d "$SCRIPT_DIR/clients/converter-test" ]; then
+    log ""
+    log "================================================================"
+    log "  STEP G: Java Converter Test Client"
+    log "================================================================"
+    if "$SCRIPTS_DIR/build-and-run-client.sh" 2>&1 | tee -a "$MASTER_LOG"; then
+        record_result "G-Java-Converter-Test: PASSED"
+    else
+        record_result "G-Java-Converter-Test: FAILED"
+    fi
+fi
+
+# Final summary
+log ""
+log "================================================================"
+log "  TEST RESULTS SUMMARY"
+log "================================================================"
+log ""
+log "Configuration:"
+log "  Kafka Version: ${KAFKA_VERSION}"
+log "  Apicurio Version: ${APICURIO_VERSION}"
+log "  Registry Image: ${REGISTRY_IMAGE}"
+log ""
+
+TOTAL_PASSED=0
+TOTAL_FAILED=0
+for result in "${STEP_RESULTS[@]}"; do
+    if [[ "$result" == *"PASSED"* ]]; then
+        log "  PASS: $result"
+        TOTAL_PASSED=$((TOTAL_PASSED + 1))
+    else
+        log "  FAIL: $result"
+        TOTAL_FAILED=$((TOTAL_FAILED + 1))
+    fi
+done
+
+log ""
+log "Total: $((TOTAL_PASSED + TOTAL_FAILED)) tests"
+log "  Passed: $TOTAL_PASSED"
+log "  Failed: $TOTAL_FAILED"
+log ""
+
+if [ "$TOTAL_FAILED" -gt 0 ]; then
+    log "OVERALL: FAILED"
+    log ""
+    log "Check individual step logs in: $LOG_DIR/"
+else
+    log "OVERALL: PASSED"
+fi
+
+log ""
+log "All logs saved to: $LOG_DIR"
+log "Master log: $MASTER_LOG"
+log ""
+log "To clean up:"
+log "  ./scripts/cleanup.sh"
+log "  ./scripts/cleanup.sh --remove-volumes --remove-data"
+log ""
+
+# Exit with failure if any test failed
+if [ "$TOTAL_FAILED" -gt 0 ]; then
+    exit 1
+fi

--- a/converter-testing/run-converter-test.sh
+++ b/converter-testing/run-converter-test.sh
@@ -10,6 +10,7 @@
 #   ./run-converter-test.sh --interactive                # Pause between steps
 #   ./run-converter-test.sh --kafka-version 3.8.1        # Test specific Kafka version
 #   ./run-converter-test.sh --apicurio-version 3.0.7.Final  # Test specific Registry version
+#   ./run-converter-test.sh --maven-repo-url https://maven.repository.redhat.com/ga  # Use Red Hat Maven repo
 
 set -e
 
@@ -30,6 +31,7 @@ PAUSE_BETWEEN_STEPS=false
 KAFKA_VERSION=""
 APICURIO_VERSION=""
 REGISTRY_IMAGE=""
+MAVEN_REPO_URL=""
 SKIP_JAVA_TEST=false
 
 while [[ $# -gt 0 ]]; do
@@ -50,13 +52,17 @@ while [[ $# -gt 0 ]]; do
             REGISTRY_IMAGE="$2"
             shift 2
             ;;
+        --maven-repo-url)
+            MAVEN_REPO_URL="$2"
+            shift 2
+            ;;
         --skip-java-test)
             SKIP_JAVA_TEST=true
             shift
             ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: $0 [--interactive] [--kafka-version VERSION] [--apicurio-version VERSION] [--registry-image IMAGE] [--skip-java-test]"
+            echo "Usage: $0 [--interactive] [--kafka-version VERSION] [--apicurio-version VERSION] [--registry-image IMAGE] [--maven-repo-url URL] [--skip-java-test]"
             exit 1
             ;;
     esac
@@ -78,6 +84,11 @@ if [ -n "$REGISTRY_IMAGE" ]; then
     sed -i.bak "s|^REGISTRY_IMAGE=.*|REGISTRY_IMAGE=$REGISTRY_IMAGE|" "$ENV_FILE"
     rm -f "$ENV_FILE.bak"
     log "Using Registry image: $REGISTRY_IMAGE"
+fi
+if [ -n "$MAVEN_REPO_URL" ]; then
+    sed -i.bak "s|^MAVEN_REPO_URL=.*|MAVEN_REPO_URL=$MAVEN_REPO_URL|" "$ENV_FILE"
+    rm -f "$ENV_FILE.bak"
+    log "Using Maven repo: $MAVEN_REPO_URL"
 fi
 
 # Read current versions from .env
@@ -102,6 +113,7 @@ log "Configuration:"
 log "  Kafka Version: ${KAFKA_VERSION:-default}"
 log "  Apicurio Version: ${APICURIO_VERSION:-default}"
 log "  Registry Image: ${REGISTRY_IMAGE:-default}"
+log "  Maven Repo: ${MAVEN_REPO_URL:-default}"
 log ""
 log "Test Steps:"
 log "  A. Deploy Kafka"

--- a/converter-testing/scripts/build-and-run-client.sh
+++ b/converter-testing/scripts/build-and-run-client.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Build and Run the Java Converter Test Client
+# This script builds the converter-test Maven project and runs it
+# against the deployed Apicurio Registry.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+CLIENT_DIR="$PROJECT_DIR/clients/converter-test"
+LOG_DIR="$PROJECT_DIR/logs"
+
+mkdir -p "$LOG_DIR"
+
+LOG_FILE="$LOG_DIR/build-and-run-client.log"
+
+log() {
+    echo "$1" | tee -a "$LOG_FILE"
+}
+
+log "================================================================"
+log "  Build and Run Java Converter Test Client"
+log "================================================================"
+log ""
+
+# Verify prerequisites
+log "[1/3] Verifying prerequisites..."
+if ! curl -sf http://localhost:8080/health/ready > /dev/null 2>&1; then
+    log "Apicurio Registry is not running. Please deploy it first."
+    exit 1
+fi
+log "  Apicurio Registry is accessible"
+
+if [ ! -f "$CLIENT_DIR/pom.xml" ]; then
+    log "Client project not found at: $CLIENT_DIR"
+    exit 1
+fi
+log "  Client project found"
+log ""
+
+# Build the client
+log "[2/3] Building converter test client..."
+cd "$CLIENT_DIR"
+if mvn clean package -DskipTests 2>&1 | tee -a "$LOG_FILE"; then
+    log ""
+    log "  Build successful"
+else
+    log ""
+    log "  Build failed"
+    exit 1
+fi
+log ""
+
+# Run the client
+JAR_PATH="$CLIENT_DIR/target/converter-test-1.0.0-SNAPSHOT.jar"
+if [ ! -f "$JAR_PATH" ]; then
+    log "JAR not found: $JAR_PATH"
+    exit 1
+fi
+
+log "[3/3] Running converter test client..."
+log ""
+
+export REGISTRY_URL="http://localhost:8080/apis/registry/v3"
+
+if java -jar "$JAR_PATH" 2>&1 | tee -a "$LOG_FILE"; then
+    log ""
+    log "================================================================"
+    log "  Java Converter Test Client completed successfully"
+    log "================================================================"
+else
+    log ""
+    log "================================================================"
+    log "  Java Converter Test Client FAILED"
+    log "================================================================"
+    exit 1
+fi
+log ""
+log "Logs saved to: $LOG_FILE"
+log ""

--- a/converter-testing/scripts/cleanup.sh
+++ b/converter-testing/scripts/cleanup.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Cleanup: Remove all converter test containers, networks, and volumes
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+ENV_FILE="$PROJECT_DIR/.env"
+
+log() {
+    echo "$1"
+}
+
+log "================================================================"
+log "  Cleanup: Kafka Connect Converter Test"
+log "================================================================"
+log ""
+
+# Parse arguments
+REMOVE_VOLUMES=false
+REMOVE_DATA=false
+for arg in "$@"; do
+    case $arg in
+        --remove-volumes) REMOVE_VOLUMES=true ;;
+        --remove-data) REMOVE_DATA=true ;;
+    esac
+done
+
+# Delete connectors first (graceful shutdown)
+log "Deleting connectors..."
+for connector in avro-file-source avro-file-sink json-file-source json-file-sink; do
+    if curl -sf "http://localhost:8083/connectors/$connector" > /dev/null 2>&1; then
+        curl -s -X DELETE "http://localhost:8083/connectors/$connector" > /dev/null 2>&1
+        log "  Deleted connector: $connector"
+    fi
+done
+log ""
+
+# Stop and remove containers
+log "Stopping containers..."
+for compose_file in docker-compose-connect.yml docker-compose-registry.yml docker-compose-kafka.yml; do
+    if [ -f "$PROJECT_DIR/$compose_file" ]; then
+        log "  Stopping services in $compose_file..."
+        docker compose --env-file "$ENV_FILE" -f "$PROJECT_DIR/$compose_file" down 2>/dev/null || true
+    fi
+done
+log ""
+
+# Remove volumes
+if [ "$REMOVE_VOLUMES" = true ]; then
+    log "Removing volumes..."
+    docker volume rm converter-connect-data 2>/dev/null || true
+    log ""
+fi
+
+# Remove network
+log "Removing network..."
+docker network rm converter-test-network 2>/dev/null || true
+log ""
+
+# Remove data and logs
+if [ "$REMOVE_DATA" = true ]; then
+    log "Removing data and logs..."
+    rm -rf "$PROJECT_DIR/data/"*
+    rm -rf "$PROJECT_DIR/logs/"*
+    log ""
+fi
+
+# Remove custom Docker image
+log "Removing custom Docker image..."
+docker rmi converter-testing-connect 2>/dev/null || true
+log ""
+
+log "================================================================"
+log "  Cleanup completed"
+log "================================================================"
+log ""
+log "To also remove volumes and data:"
+log "  $0 --remove-volumes --remove-data"
+log ""

--- a/converter-testing/scripts/step-A-deploy-kafka.sh
+++ b/converter-testing/scripts/step-A-deploy-kafka.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Step A: Deploy Kafka Cluster
+# This script deploys Apache Kafka using KRaft mode (no Zookeeper)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+COMPOSE_FILE="$PROJECT_DIR/docker-compose-kafka.yml"
+ENV_FILE="$PROJECT_DIR/.env"
+LOG_DIR="$PROJECT_DIR/logs"
+CONTAINER_LOG_DIR="$LOG_DIR/containers"
+
+# Create log directories
+mkdir -p "$LOG_DIR"
+mkdir -p "$CONTAINER_LOG_DIR"
+
+LOG_FILE="$LOG_DIR/step-A-deploy-kafka.log"
+
+log() {
+    echo "$1" | tee -a "$LOG_FILE"
+}
+
+wait_for_kafka() {
+    local timeout=${1:-90}
+    local interval=2
+    local elapsed=0
+
+    log "Waiting for Kafka broker to be ready (timeout: ${timeout}s)..."
+    while [ $elapsed -lt $timeout ]; do
+        if docker exec converter-kafka /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 > /dev/null 2>&1; then
+            log "Kafka broker is ready after ${elapsed}s"
+            return 0
+        fi
+        echo -n "."
+        sleep $interval
+        elapsed=$((elapsed + interval))
+    done
+
+    log ""
+    log "Kafka broker failed to start after ${timeout}s"
+    return 1
+}
+
+log "================================================================"
+log "  Step A: Deploy Kafka Cluster"
+log "================================================================"
+log ""
+
+# Step 1: Start Kafka
+log "[1/4] Starting Kafka using KRaft mode..."
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d
+log ""
+
+# Step 2: Wait for Kafka to be ready
+log "[2/4] Waiting for Kafka broker to be ready..."
+if ! wait_for_kafka 90; then
+    log ""
+    log "Failed to start Kafka. Check logs:"
+    log "  docker logs converter-kafka"
+    exit 1
+fi
+log ""
+
+# Step 3: Verify broker
+log "[3/4] Verifying Kafka broker..."
+docker exec converter-kafka /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 2>&1 | head -n 5 | tee -a "$LOG_FILE"
+log ""
+
+# Step 4: Create test topics
+log "[4/4] Creating test topics..."
+for topic in avro-converter-test json-converter-test; do
+    docker exec converter-kafka /opt/kafka/bin/kafka-topics.sh \
+        --bootstrap-server localhost:9092 \
+        --create \
+        --topic "$topic" \
+        --partitions 1 \
+        --replication-factor 1 \
+        --if-not-exists 2>&1 | tee -a "$LOG_FILE"
+done
+log ""
+
+# Verify topics
+log "Verifying topics..."
+docker exec converter-kafka /opt/kafka/bin/kafka-topics.sh \
+    --bootstrap-server localhost:9092 \
+    --list 2>&1 | tee -a "$LOG_FILE"
+log ""
+
+# Collect container logs
+docker logs converter-kafka > "$CONTAINER_LOG_DIR/kafka-initial.log" 2>&1
+
+log "================================================================"
+log "  Step A completed successfully"
+log "================================================================"
+log ""
+log "Kafka is running at: localhost:9092"
+log "Topics created: avro-converter-test, json-converter-test"
+log "Logs saved to: $LOG_FILE"
+log ""

--- a/converter-testing/scripts/step-B-deploy-registry.sh
+++ b/converter-testing/scripts/step-B-deploy-registry.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Step B: Deploy Apicurio Registry
+# This script deploys Apicurio Registry in in-memory (H2) mode
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+COMPOSE_FILE="$PROJECT_DIR/docker-compose-registry.yml"
+ENV_FILE="$PROJECT_DIR/.env"
+LOG_DIR="$PROJECT_DIR/logs"
+CONTAINER_LOG_DIR="$LOG_DIR/containers"
+
+mkdir -p "$LOG_DIR"
+mkdir -p "$CONTAINER_LOG_DIR"
+
+LOG_FILE="$LOG_DIR/step-B-deploy-registry.log"
+
+log() {
+    echo "$1" | tee -a "$LOG_FILE"
+}
+
+wait_for_url() {
+    local url=$1
+    local timeout=${2:-60}
+    local interval=2
+    local elapsed=0
+
+    log "Waiting for $url to be healthy (timeout: ${timeout}s)..."
+    while [ $elapsed -lt $timeout ]; do
+        if curl -sf "$url" > /dev/null 2>&1; then
+            log "Health check passed after ${elapsed}s"
+            return 0
+        fi
+        echo -n "."
+        sleep $interval
+        elapsed=$((elapsed + interval))
+    done
+
+    log ""
+    log "Health check failed after ${timeout}s"
+    return 1
+}
+
+log "================================================================"
+log "  Step B: Deploy Apicurio Registry"
+log "================================================================"
+log ""
+
+# Step 1: Start Registry
+log "[1/3] Starting Apicurio Registry (in-memory mode)..."
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d
+log ""
+
+# Step 2: Wait for Registry to be ready
+log "[2/3] Waiting for Registry to be ready..."
+if ! wait_for_url "http://localhost:8080/health/ready" 60; then
+    log ""
+    log "Failed to start Registry. Check logs:"
+    log "  docker logs converter-registry"
+    exit 1
+fi
+log ""
+
+# Step 3: Verify Registry
+log "[3/3] Verifying Registry..."
+SYSTEM_INFO=$(curl -s http://localhost:8080/apis/registry/v3/system/info)
+log "Registry System Info:"
+log "  $SYSTEM_INFO"
+log ""
+
+# Collect container logs
+docker logs converter-registry > "$CONTAINER_LOG_DIR/registry-initial.log" 2>&1
+
+log "================================================================"
+log "  Step B completed successfully"
+log "================================================================"
+log ""
+log "Apicurio Registry is running at: http://localhost:8080"
+log "API v3 URL: http://localhost:8080/apis/registry/v3"
+log "Logs saved to: $LOG_FILE"
+log ""

--- a/converter-testing/scripts/step-C-deploy-connect.sh
+++ b/converter-testing/scripts/step-C-deploy-connect.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Step C: Deploy Kafka Connect with Apicurio Registry Converter Plugin
+# This script builds and deploys a custom Kafka Connect image that includes
+# the Apicurio Registry converter distribution.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+COMPOSE_FILE="$PROJECT_DIR/docker-compose-connect.yml"
+ENV_FILE="$PROJECT_DIR/.env"
+LOG_DIR="$PROJECT_DIR/logs"
+CONTAINER_LOG_DIR="$LOG_DIR/containers"
+
+mkdir -p "$LOG_DIR"
+mkdir -p "$CONTAINER_LOG_DIR"
+
+LOG_FILE="$LOG_DIR/step-C-deploy-connect.log"
+
+log() {
+    echo "$1" | tee -a "$LOG_FILE"
+}
+
+wait_for_url() {
+    local url=$1
+    local timeout=${2:-120}
+    local interval=3
+    local elapsed=0
+
+    log "Waiting for $url to be healthy (timeout: ${timeout}s)..."
+    while [ $elapsed -lt $timeout ]; do
+        if curl -sf "$url" > /dev/null 2>&1; then
+            log "Health check passed after ${elapsed}s"
+            return 0
+        fi
+        echo -n "."
+        sleep $interval
+        elapsed=$((elapsed + interval))
+    done
+
+    log ""
+    log "Health check failed after ${timeout}s"
+    return 1
+}
+
+log "================================================================"
+log "  Step C: Deploy Kafka Connect"
+log "================================================================"
+log ""
+
+# Step 1: Build custom Connect image
+log "[1/4] Building Kafka Connect image with Apicurio converter..."
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" build connect 2>&1 | tee -a "$LOG_FILE"
+log ""
+
+# Step 2: Create data directory for connectors inside the Connect container
+log "[2/4] Starting Kafka Connect..."
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d connect 2>&1 | tee -a "$LOG_FILE"
+log ""
+
+# Step 3: Wait for Connect to be ready
+log "[3/4] Waiting for Kafka Connect to be ready..."
+if ! wait_for_url "http://localhost:8083/" 120; then
+    log ""
+    log "Failed to start Kafka Connect. Check logs:"
+    log "  docker logs converter-connect"
+    exit 1
+fi
+log ""
+
+# Step 4: Verify Connect and list available plugins
+log "[4/4] Verifying Kafka Connect and available plugins..."
+CONNECT_INFO=$(curl -s http://localhost:8083/)
+log "Connect Worker Info:"
+log "  $CONNECT_INFO"
+log ""
+
+log "Available connector plugins:"
+curl -s http://localhost:8083/connector-plugins | jq -r '.[].class' 2>/dev/null | tee -a "$LOG_FILE"
+log ""
+
+# Check if Apicurio converter classes are available
+log "Checking Apicurio converter availability..."
+PLUGINS=$(curl -s http://localhost:8083/connector-plugins)
+log "  Connector plugins loaded: $(echo "$PLUGINS" | jq length)"
+log ""
+
+# Verify converter JARs are present
+log "Verifying converter JARs in plugin path..."
+docker exec converter-connect ls -la /opt/kafka/connect-plugins/apicurio-converter/ 2>&1 | tee -a "$LOG_FILE"
+log ""
+
+# Prepare data directory
+log "Preparing data directory..."
+docker exec converter-connect mkdir -p /data
+docker exec converter-connect sh -c 'touch /data/avro-source-input.txt /data/json-source-input.txt'
+log ""
+
+# Collect container logs
+docker logs converter-connect > "$CONTAINER_LOG_DIR/connect-initial.log" 2>&1
+
+log "================================================================"
+log "  Step C completed successfully"
+log "================================================================"
+log ""
+log "Kafka Connect is running at: http://localhost:8083"
+log "Plugin path: /opt/kafka/connect-plugins"
+log "Logs saved to: $LOG_FILE"
+log ""

--- a/converter-testing/scripts/step-D-test-avro-converter.sh
+++ b/converter-testing/scripts/step-D-test-avro-converter.sh
@@ -1,0 +1,234 @@
+#!/bin/bash
+
+# Step D: Test Avro Converter
+# This script tests the Apicurio Registry Avro converter by:
+# 1. Creating a FileStreamSource connector with Avro converter
+# 2. Writing test data to the source file
+# 3. Creating a FileStreamSink connector with Avro converter
+# 4. Verifying data flows through correctly
+# 5. Checking schema registration in Apicurio Registry
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+CONNECTORS_DIR="$PROJECT_DIR/connectors"
+LOG_DIR="$PROJECT_DIR/logs"
+DATA_DIR="$PROJECT_DIR/data"
+
+mkdir -p "$LOG_DIR"
+mkdir -p "$DATA_DIR"
+
+LOG_FILE="$LOG_DIR/step-D-test-avro-converter.log"
+
+log() {
+    echo "$1" | tee -a "$LOG_FILE"
+}
+
+CONNECT_URL="http://localhost:8083"
+REGISTRY_URL="http://localhost:8080"
+
+log "================================================================"
+log "  Step D: Test Avro Converter"
+log "================================================================"
+log ""
+
+# Step 1: Verify prerequisites
+log "[1/7] Verifying prerequisites..."
+if ! curl -sf "$CONNECT_URL/" > /dev/null 2>&1; then
+    log "Kafka Connect is not running. Please run step-C-deploy-connect.sh first."
+    exit 1
+fi
+log "  Kafka Connect is running"
+
+if ! curl -sf "$REGISTRY_URL/health/ready" > /dev/null 2>&1; then
+    log "Apicurio Registry is not running. Please run step-B-deploy-registry.sh first."
+    exit 1
+fi
+log "  Apicurio Registry is running"
+log ""
+
+# Step 2: Write test data to source file
+log "[2/7] Writing test data to source file..."
+TEST_LINES=(
+    "Hello from Avro converter test - line 1"
+    "Testing serialization with Apicurio Registry - line 2"
+    "Kafka Connect converter integration test - line 3"
+    "Verifying schema registration works - line 4"
+    "Final test message for Avro converter - line 5"
+)
+
+for line in "${TEST_LINES[@]}"; do
+    docker exec converter-connect sh -c "echo '$line' >> /data/avro-source-input.txt"
+done
+log "  Wrote ${#TEST_LINES[@]} lines to source file"
+log ""
+
+# Step 3: Create source connector with Avro converter
+log "[3/7] Creating Avro FileStreamSource connector..."
+SOURCE_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+    -H "Content-Type: application/json" \
+    -d @"$CONNECTORS_DIR/avro-file-source.json" \
+    "$CONNECT_URL/connectors")
+
+SOURCE_HTTP_CODE=$(echo "$SOURCE_RESPONSE" | tail -1)
+SOURCE_BODY=$(echo "$SOURCE_RESPONSE" | head -n -1)
+
+if [ "$SOURCE_HTTP_CODE" = "201" ] || [ "$SOURCE_HTTP_CODE" = "200" ]; then
+    log "  Source connector created successfully (HTTP $SOURCE_HTTP_CODE)"
+elif [ "$SOURCE_HTTP_CODE" = "409" ]; then
+    log "  Source connector already exists, deleting and recreating..."
+    curl -s -X DELETE "$CONNECT_URL/connectors/avro-file-source" > /dev/null 2>&1
+    sleep 2
+    SOURCE_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -d @"$CONNECTORS_DIR/avro-file-source.json" \
+        "$CONNECT_URL/connectors")
+    SOURCE_HTTP_CODE=$(echo "$SOURCE_RESPONSE" | tail -1)
+    if [ "$SOURCE_HTTP_CODE" = "201" ] || [ "$SOURCE_HTTP_CODE" = "200" ]; then
+        log "  Source connector recreated successfully"
+    else
+        log "  Failed to create source connector (HTTP $SOURCE_HTTP_CODE)"
+        log "  Response: $SOURCE_BODY"
+        exit 1
+    fi
+else
+    log "  Failed to create source connector (HTTP $SOURCE_HTTP_CODE)"
+    log "  Response: $SOURCE_BODY"
+    exit 1
+fi
+log ""
+
+# Step 4: Wait for source connector to process data
+log "[4/7] Waiting for source connector to process data..."
+sleep 10
+
+# Check source connector status
+SOURCE_STATUS=$(curl -s "$CONNECT_URL/connectors/avro-file-source/status")
+SOURCE_STATE=$(echo "$SOURCE_STATUS" | jq -r '.connector.state')
+log "  Source connector state: $SOURCE_STATE"
+
+if [ "$SOURCE_STATE" != "RUNNING" ]; then
+    log "  WARNING: Source connector is not RUNNING"
+    log "  Full status: $SOURCE_STATUS"
+fi
+
+# Check task status
+TASK_STATE=$(echo "$SOURCE_STATUS" | jq -r '.tasks[0].state // "UNKNOWN"')
+log "  Source task state: $TASK_STATE"
+if [ "$TASK_STATE" = "FAILED" ]; then
+    TASK_TRACE=$(echo "$SOURCE_STATUS" | jq -r '.tasks[0].trace // "no trace"')
+    log "  Task error trace: $TASK_TRACE"
+fi
+log ""
+
+# Step 5: Create sink connector with Avro converter
+log "[5/7] Creating Avro FileStreamSink connector..."
+SINK_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+    -H "Content-Type: application/json" \
+    -d @"$CONNECTORS_DIR/avro-file-sink.json" \
+    "$CONNECT_URL/connectors")
+
+SINK_HTTP_CODE=$(echo "$SINK_RESPONSE" | tail -1)
+SINK_BODY=$(echo "$SINK_RESPONSE" | head -n -1)
+
+if [ "$SINK_HTTP_CODE" = "201" ] || [ "$SINK_HTTP_CODE" = "200" ]; then
+    log "  Sink connector created successfully (HTTP $SINK_HTTP_CODE)"
+elif [ "$SINK_HTTP_CODE" = "409" ]; then
+    log "  Sink connector already exists, deleting and recreating..."
+    curl -s -X DELETE "$CONNECT_URL/connectors/avro-file-sink" > /dev/null 2>&1
+    sleep 2
+    SINK_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -d @"$CONNECTORS_DIR/avro-file-sink.json" \
+        "$CONNECT_URL/connectors")
+    SINK_HTTP_CODE=$(echo "$SINK_RESPONSE" | tail -1)
+    if [ "$SINK_HTTP_CODE" = "201" ] || [ "$SINK_HTTP_CODE" = "200" ]; then
+        log "  Sink connector recreated successfully"
+    else
+        log "  Failed to create sink connector (HTTP $SINK_HTTP_CODE)"
+        log "  Response: $SINK_BODY"
+        exit 1
+    fi
+else
+    log "  Failed to create sink connector (HTTP $SINK_HTTP_CODE)"
+    log "  Response: $SINK_BODY"
+    exit 1
+fi
+log ""
+
+# Step 6: Wait and verify sink output
+log "[6/7] Waiting for sink connector to consume data..."
+sleep 15
+
+SINK_STATUS=$(curl -s "$CONNECT_URL/connectors/avro-file-sink/status")
+SINK_STATE=$(echo "$SINK_STATUS" | jq -r '.connector.state')
+log "  Sink connector state: $SINK_STATE"
+
+SINK_TASK_STATE=$(echo "$SINK_STATUS" | jq -r '.tasks[0].state // "UNKNOWN"')
+log "  Sink task state: $SINK_TASK_STATE"
+if [ "$SINK_TASK_STATE" = "FAILED" ]; then
+    SINK_TASK_TRACE=$(echo "$SINK_STATUS" | jq -r '.tasks[0].trace // "no trace"')
+    log "  Sink task error trace: $SINK_TASK_TRACE"
+fi
+
+# Check sink output file
+log ""
+log "Checking sink output..."
+SINK_CONTENT=$(docker exec converter-connect cat /data/avro-sink-output.txt 2>/dev/null || echo "")
+if [ -n "$SINK_CONTENT" ]; then
+    SINK_LINE_COUNT=$(echo "$SINK_CONTENT" | wc -l | tr -d ' ')
+    log "  Sink output has $SINK_LINE_COUNT lines:"
+    echo "$SINK_CONTENT" | while IFS= read -r line; do
+        log "    $line"
+    done
+
+    # Save output for comparison
+    echo "$SINK_CONTENT" > "$DATA_DIR/avro-sink-output.txt"
+else
+    log "  Sink output file is empty or not found"
+    log "  This may indicate the converter failed to deserialize the data"
+fi
+log ""
+
+# Step 7: Verify topic has data
+log "[7/7] Verifying Kafka topic..."
+TOPIC_OFFSET=$(docker exec converter-kafka /opt/kafka/bin/kafka-run-class.sh kafka.tools.GetOffsetShell \
+    --broker-list localhost:9092 \
+    --topic avro-converter-test 2>/dev/null | awk -F: '{sum+=$3} END {print sum+0}')
+log "  Messages in avro-converter-test topic: $TOPIC_OFFSET"
+log ""
+
+# Report results
+AVRO_TEST_PASSED=true
+if [ "$SOURCE_STATE" != "RUNNING" ]; then
+    AVRO_TEST_PASSED=false
+    log "FAIL: Source connector is not running"
+fi
+if [ "$TASK_STATE" = "FAILED" ]; then
+    AVRO_TEST_PASSED=false
+    log "FAIL: Source task failed"
+fi
+if [ "$TOPIC_OFFSET" -eq 0 ]; then
+    AVRO_TEST_PASSED=false
+    log "FAIL: No messages in topic"
+fi
+
+# Collect container logs
+docker logs converter-connect > "$LOG_DIR/containers/connect-after-avro.log" 2>&1
+
+log "================================================================"
+if [ "$AVRO_TEST_PASSED" = true ]; then
+    log "  Step D completed successfully - Avro Converter PASSED"
+else
+    log "  Step D completed with issues - check logs above"
+fi
+log "================================================================"
+log ""
+log "Connectors status:"
+log "  Source: $SOURCE_STATE (task: $TASK_STATE)"
+log "  Sink: $SINK_STATE (task: $SINK_TASK_STATE)"
+log "  Messages in topic: $TOPIC_OFFSET"
+log ""
+log "Logs saved to: $LOG_FILE"
+log ""

--- a/converter-testing/scripts/step-E-test-json-converter.sh
+++ b/converter-testing/scripts/step-E-test-json-converter.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+
+# Step E: Test ExtJSON Converter
+# This script tests the Apicurio Registry ExtJSON converter by:
+# 1. Creating a FileStreamSource connector with ExtJSON converter
+# 2. Writing test data to the source file
+# 3. Creating a FileStreamSink connector with ExtJSON converter
+# 4. Verifying data flows through correctly
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+CONNECTORS_DIR="$PROJECT_DIR/connectors"
+LOG_DIR="$PROJECT_DIR/logs"
+DATA_DIR="$PROJECT_DIR/data"
+
+mkdir -p "$LOG_DIR"
+mkdir -p "$DATA_DIR"
+
+LOG_FILE="$LOG_DIR/step-E-test-json-converter.log"
+
+log() {
+    echo "$1" | tee -a "$LOG_FILE"
+}
+
+CONNECT_URL="http://localhost:8083"
+REGISTRY_URL="http://localhost:8080"
+
+log "================================================================"
+log "  Step E: Test ExtJSON Converter"
+log "================================================================"
+log ""
+
+# Step 1: Verify prerequisites
+log "[1/6] Verifying prerequisites..."
+if ! curl -sf "$CONNECT_URL/" > /dev/null 2>&1; then
+    log "Kafka Connect is not running."
+    exit 1
+fi
+log "  Kafka Connect is running"
+log ""
+
+# Step 2: Write test data
+log "[2/6] Writing test data to source file..."
+TEST_LINES=(
+    "JSON converter test message 1"
+    "ExtJSON serialization verification - line 2"
+    "Schema registry integration test - line 3"
+)
+
+for line in "${TEST_LINES[@]}"; do
+    docker exec converter-connect sh -c "echo '$line' >> /data/json-source-input.txt"
+done
+log "  Wrote ${#TEST_LINES[@]} lines to source file"
+log ""
+
+# Step 3: Create source connector
+log "[3/6] Creating ExtJSON FileStreamSource connector..."
+SOURCE_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+    -H "Content-Type: application/json" \
+    -d @"$CONNECTORS_DIR/json-file-source.json" \
+    "$CONNECT_URL/connectors")
+
+SOURCE_HTTP_CODE=$(echo "$SOURCE_RESPONSE" | tail -1)
+if [ "$SOURCE_HTTP_CODE" = "201" ] || [ "$SOURCE_HTTP_CODE" = "200" ]; then
+    log "  Source connector created successfully"
+elif [ "$SOURCE_HTTP_CODE" = "409" ]; then
+    curl -s -X DELETE "$CONNECT_URL/connectors/json-file-source" > /dev/null 2>&1
+    sleep 2
+    curl -s -X POST -H "Content-Type: application/json" \
+        -d @"$CONNECTORS_DIR/json-file-source.json" \
+        "$CONNECT_URL/connectors" > /dev/null
+    log "  Source connector recreated"
+else
+    log "  Failed to create source connector (HTTP $SOURCE_HTTP_CODE)"
+    exit 1
+fi
+log ""
+
+# Step 4: Wait for data processing
+log "[4/6] Waiting for source connector to process data..."
+sleep 10
+
+SOURCE_STATUS=$(curl -s "$CONNECT_URL/connectors/json-file-source/status")
+SOURCE_STATE=$(echo "$SOURCE_STATUS" | jq -r '.connector.state')
+TASK_STATE=$(echo "$SOURCE_STATUS" | jq -r '.tasks[0].state // "UNKNOWN"')
+log "  Source connector: $SOURCE_STATE, task: $TASK_STATE"
+if [ "$TASK_STATE" = "FAILED" ]; then
+    TASK_TRACE=$(echo "$SOURCE_STATUS" | jq -r '.tasks[0].trace // "no trace"')
+    log "  Task error: $TASK_TRACE"
+fi
+log ""
+
+# Step 5: Create sink connector
+log "[5/6] Creating ExtJSON FileStreamSink connector..."
+SINK_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+    -H "Content-Type: application/json" \
+    -d @"$CONNECTORS_DIR/json-file-sink.json" \
+    "$CONNECT_URL/connectors")
+
+SINK_HTTP_CODE=$(echo "$SINK_RESPONSE" | tail -1)
+if [ "$SINK_HTTP_CODE" = "201" ] || [ "$SINK_HTTP_CODE" = "200" ]; then
+    log "  Sink connector created successfully"
+elif [ "$SINK_HTTP_CODE" = "409" ]; then
+    curl -s -X DELETE "$CONNECT_URL/connectors/json-file-sink" > /dev/null 2>&1
+    sleep 2
+    curl -s -X POST -H "Content-Type: application/json" \
+        -d @"$CONNECTORS_DIR/json-file-sink.json" \
+        "$CONNECT_URL/connectors" > /dev/null
+    log "  Sink connector recreated"
+else
+    log "  Failed to create sink connector (HTTP $SINK_HTTP_CODE)"
+    exit 1
+fi
+log ""
+
+# Step 6: Verify
+log "[6/6] Waiting and verifying results..."
+sleep 15
+
+SINK_STATUS=$(curl -s "$CONNECT_URL/connectors/json-file-sink/status")
+SINK_STATE=$(echo "$SINK_STATUS" | jq -r '.connector.state')
+SINK_TASK_STATE=$(echo "$SINK_STATUS" | jq -r '.tasks[0].state // "UNKNOWN"')
+log "  Sink connector: $SINK_STATE, task: $SINK_TASK_STATE"
+if [ "$SINK_TASK_STATE" = "FAILED" ]; then
+    SINK_TRACE=$(echo "$SINK_STATUS" | jq -r '.tasks[0].trace // "no trace"')
+    log "  Sink task error: $SINK_TRACE"
+fi
+
+SINK_CONTENT=$(docker exec converter-connect cat /data/json-sink-output.txt 2>/dev/null || echo "")
+if [ -n "$SINK_CONTENT" ]; then
+    SINK_LINE_COUNT=$(echo "$SINK_CONTENT" | wc -l | tr -d ' ')
+    log "  Sink output has $SINK_LINE_COUNT lines"
+    echo "$SINK_CONTENT" > "$DATA_DIR/json-sink-output.txt"
+else
+    log "  Sink output file is empty or not found"
+fi
+
+TOPIC_OFFSET=$(docker exec converter-kafka /opt/kafka/bin/kafka-run-class.sh kafka.tools.GetOffsetShell \
+    --broker-list localhost:9092 \
+    --topic json-converter-test 2>/dev/null | awk -F: '{sum+=$3} END {print sum+0}')
+log "  Messages in json-converter-test topic: $TOPIC_OFFSET"
+log ""
+
+docker logs converter-connect > "$LOG_DIR/containers/connect-after-json.log" 2>&1
+
+JSON_TEST_PASSED=true
+if [ "$SOURCE_STATE" != "RUNNING" ]; then JSON_TEST_PASSED=false; fi
+if [ "$TASK_STATE" = "FAILED" ]; then JSON_TEST_PASSED=false; fi
+if [ "$TOPIC_OFFSET" -eq 0 ]; then JSON_TEST_PASSED=false; fi
+
+log "================================================================"
+if [ "$JSON_TEST_PASSED" = true ]; then
+    log "  Step E completed successfully - ExtJSON Converter PASSED"
+else
+    log "  Step E completed with issues - check logs above"
+fi
+log "================================================================"
+log ""
+log "Logs saved to: $LOG_FILE"
+log ""

--- a/converter-testing/scripts/step-F-verify-schemas.sh
+++ b/converter-testing/scripts/step-F-verify-schemas.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+# Step F: Verify Schemas in Apicurio Registry
+# This script verifies that the Kafka Connect converters correctly
+# registered schemas in the Apicurio Registry.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+LOG_DIR="$PROJECT_DIR/logs"
+DATA_DIR="$PROJECT_DIR/data"
+
+mkdir -p "$LOG_DIR"
+mkdir -p "$DATA_DIR"
+
+LOG_FILE="$LOG_DIR/step-F-verify-schemas.log"
+
+log() {
+    echo "$1" | tee -a "$LOG_FILE"
+}
+
+REGISTRY_URL="http://localhost:8080"
+REGISTRY_API="$REGISTRY_URL/apis/registry/v3"
+
+log "================================================================"
+log "  Step F: Verify Schemas in Apicurio Registry"
+log "================================================================"
+log ""
+
+# Step 1: List all groups
+log "[1/4] Listing groups..."
+GROUPS=$(curl -s "$REGISTRY_API/groups" | jq -r '.groups[].groupId' 2>/dev/null || echo "")
+if [ -n "$GROUPS" ]; then
+    echo "$GROUPS" | while IFS= read -r group; do
+        log "  Group: $group"
+    done
+else
+    log "  No groups found (artifacts may be in the default group)"
+fi
+log ""
+
+# Step 2: Search for all artifacts
+log "[2/4] Searching for registered artifacts..."
+SEARCH_RESULT=$(curl -s "$REGISTRY_API/search/artifacts")
+ARTIFACT_COUNT=$(echo "$SEARCH_RESULT" | jq -r '.count // 0' 2>/dev/null)
+log "  Total artifacts registered: $ARTIFACT_COUNT"
+log ""
+
+if [ "$ARTIFACT_COUNT" -gt 0 ]; then
+    echo "$SEARCH_RESULT" | jq -r '.artifacts[] | "  - [\(.groupId // "default")] \(.artifactId) (type: \(.artifactType // "unknown"))"' 2>/dev/null | tee -a "$LOG_FILE"
+    log ""
+fi
+
+# Step 3: Get details for each artifact
+log "[3/4] Getting artifact details..."
+if [ "$ARTIFACT_COUNT" -gt 0 ]; then
+    echo "$SEARCH_RESULT" | jq -c '.artifacts[]' 2>/dev/null | while IFS= read -r artifact; do
+        GROUP_ID=$(echo "$artifact" | jq -r '.groupId // "default"')
+        ARTIFACT_ID=$(echo "$artifact" | jq -r '.artifactId')
+        ARTIFACT_TYPE=$(echo "$artifact" | jq -r '.artifactType // "unknown"')
+
+        log ""
+        log "  Artifact: $ARTIFACT_ID"
+        log "    Group: $GROUP_ID"
+        log "    Type: $ARTIFACT_TYPE"
+
+        # Get versions
+        VERSIONS=$(curl -s "$REGISTRY_API/groups/$GROUP_ID/artifacts/$ARTIFACT_ID/versions")
+        VERSION_COUNT=$(echo "$VERSIONS" | jq -r '.count // 0' 2>/dev/null)
+        log "    Versions: $VERSION_COUNT"
+
+        # Get latest version content
+        LATEST_VERSION=$(echo "$VERSIONS" | jq -r '.versions[0].version // "1"' 2>/dev/null)
+        CONTENT=$(curl -s "$REGISTRY_API/groups/$GROUP_ID/artifacts/$ARTIFACT_ID/versions/$LATEST_VERSION/content" 2>/dev/null)
+        if [ -n "$CONTENT" ]; then
+            log "    Latest version ($LATEST_VERSION) content:"
+            echo "$CONTENT" | jq '.' 2>/dev/null | head -20 | while IFS= read -r line; do
+                log "      $line"
+            done
+            # If jq failed (not JSON), show raw content
+            if [ $? -ne 0 ]; then
+                echo "$CONTENT" | head -5 | while IFS= read -r line; do
+                    log "      $line"
+                done
+            fi
+        fi
+    done
+else
+    log "  No artifacts to inspect"
+fi
+log ""
+
+# Step 4: Generate summary report
+log "[4/4] Generating verification report..."
+REPORT_FILE="$DATA_DIR/schema-verification-report.txt"
+
+cat > "$REPORT_FILE" <<EOF
+================================================================
+  Schema Verification Report
+================================================================
+
+Date: $(date)
+Registry URL: $REGISTRY_URL
+
+Artifacts Registered: $ARTIFACT_COUNT
+
+Groups:
+$(echo "$GROUPS" | sed 's/^/  - /' 2>/dev/null || echo "  (none)")
+
+Artifacts:
+$(echo "$SEARCH_RESULT" | jq -r '.artifacts[] | "  - [\(.groupId // "default")] \(.artifactId) (type: \(.artifactType // "unknown"))"' 2>/dev/null || echo "  (none)")
+
+Connector Status:
+$(curl -s http://localhost:8083/connectors 2>/dev/null | jq -r '.[]' 2>/dev/null | while read -r name; do
+    STATUS=$(curl -s "http://localhost:8083/connectors/$name/status" | jq -r '.connector.state' 2>/dev/null)
+    echo "  - $name: $STATUS"
+done)
+
+================================================================
+EOF
+
+log "Report saved to: $REPORT_FILE"
+log ""
+
+log "================================================================"
+if [ "$ARTIFACT_COUNT" -gt 0 ]; then
+    log "  Step F completed - $ARTIFACT_COUNT schemas verified"
+else
+    log "  Step F completed - No schemas found in registry"
+    log "  Note: This may be expected if FileStreamSource produces"
+    log "  simple string data without a complex schema."
+fi
+log "================================================================"
+log ""
+log "Logs saved to: $LOG_FILE"
+log ""


### PR DESCRIPTION
## Summary
- Add comprehensive test scenario for the Apicurio Registry Kafka Connect converter package (`AvroConverter`, `ExtJsonConverter`, `SerdeBasedConverter`)
- Docker-based integration tests: deploys Kafka + Apicurio Registry + Kafka Connect with the converter plugin, creates source/sink connectors, and verifies data flow and schema registration
- Standalone Java test client that directly validates converter API serialization/deserialization roundtrips
- Parameterized Kafka and Apicurio versions via `--kafka-version` and `--apicurio-version` flags

## Test plan
- [ ] Run `./run-converter-test.sh` with default versions (Kafka 3.9.1, Apicurio 3.0.7.Final)
- [ ] Run with alternative Kafka version: `./run-converter-test.sh --kafka-version 3.8.1`
- [ ] Verify Avro converter source/sink connectors process data correctly
- [ ] Verify ExtJSON converter source/sink connectors process data correctly
- [ ] Verify schemas are registered in Apicurio Registry
- [ ] Run Java converter test client: `./scripts/build-and-run-client.sh`
- [ ] Cleanup: `./scripts/cleanup.sh --remove-volumes --remove-data`