### PR TITLE
Export DAST scan results to ProdSec GCS bucket

### DIFF
--- a/.github/workflows/test-registry-release.yaml
+++ b/.github/workflows/test-registry-release.yaml
@@ -762,7 +762,7 @@ jobs:
     env:
       CLUSTER_NAME: ci420
       NAMESPACE: inmemory
-      RAPIDAST_TAG: development
+      RAPIDAST_TAG: 2.12.1
 
     steps:
       - name: Checkout Code
@@ -774,6 +774,11 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Write GCS key file
+        if: inputs.isDownstream == 'true'
+        run: |
+          echo "${{ secrets.GCS_SA_KEY }}" > ${{ runner.temp }}/gcs-key.json
+
       - name: Restore cluster state
         if: always()
         uses: ./.github/actions/restore-cluster-state
@@ -782,7 +787,11 @@ jobs:
 
       - name: Run DAST Scanner (v3)
         run: |
-          ./run-dast-scan.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE --config registry_v3_unauthenticated.yaml --tag $RAPIDAST_TAG
+          GCS_ARGS=""
+          if [ -f "${{ runner.temp }}/gcs-key.json" ]; then
+            GCS_ARGS="--gcsKeyFile ${{ runner.temp }}/gcs-key.json"
+          fi
+          ./run-dast-scan.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE --config registry_v3_unauthenticated.yaml --tag $RAPIDAST_TAG $GCS_ARGS
 
       - name: Commit DAST scan results to repository
         uses: ./.github/actions/commit-dast-scan-results
@@ -795,7 +804,11 @@ jobs:
 
       - name: Run DAST Scanner (v2)
         run: |
-          ./run-dast-scan.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE --config registry_v2_unauthenticated.yaml --tag $RAPIDAST_TAG
+          GCS_ARGS=""
+          if [ -f "${{ runner.temp }}/gcs-key.json" ]; then
+            GCS_ARGS="--gcsKeyFile ${{ runner.temp }}/gcs-key.json"
+          fi
+          ./run-dast-scan.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE --config registry_v2_unauthenticated.yaml --tag $RAPIDAST_TAG $GCS_ARGS
 
       - name: Commit DAST scan results to repository
         uses: ./.github/actions/commit-dast-scan-results
@@ -808,7 +821,11 @@ jobs:
 
       - name: Run DAST Scanner (ccompat v7)
         run: |
-          ./run-dast-scan.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE --config ccompat_v7_unauthenticated.yaml --tag $RAPIDAST_TAG
+          GCS_ARGS=""
+          if [ -f "${{ runner.temp }}/gcs-key.json" ]; then
+            GCS_ARGS="--gcsKeyFile ${{ runner.temp }}/gcs-key.json"
+          fi
+          ./run-dast-scan.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE --config ccompat_v7_unauthenticated.yaml --tag $RAPIDAST_TAG $GCS_ARGS
 
       - name: Commit DAST scan results to repository
         uses: ./.github/actions/commit-dast-scan-results
@@ -1412,7 +1429,7 @@ jobs:
     env:
       CLUSTER_NAME: ci420
       NAMESPACE: keycloak26
-      RAPIDAST_TAG: development
+      RAPIDAST_TAG: 2.12.1
 
     steps:
       - name: Checkout Code
@@ -1424,6 +1441,11 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Write GCS key file
+        if: inputs.isDownstream == 'true'
+        run: |
+          echo "${{ secrets.GCS_SA_KEY }}" > ${{ runner.temp }}/gcs-key.json
+
       - name: Restore cluster state
         if: always()
         uses: ./.github/actions/restore-cluster-state
@@ -1432,7 +1454,11 @@ jobs:
 
       - name: Run DAST Scanner (v3)
         run: |
-          ./run-dast-scan.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE --config registry_v3_authenticated.yaml --tag $RAPIDAST_TAG --authEnabled true
+          GCS_ARGS=""
+          if [ -f "${{ runner.temp }}/gcs-key.json" ]; then
+            GCS_ARGS="--gcsKeyFile ${{ runner.temp }}/gcs-key.json"
+          fi
+          ./run-dast-scan.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE --config registry_v3_authenticated.yaml --tag $RAPIDAST_TAG --authEnabled true $GCS_ARGS
 
       - name: Commit DAST scan results to repository
         uses: ./.github/actions/commit-dast-scan-results
@@ -1445,7 +1471,11 @@ jobs:
 
       - name: Run DAST Scanner (v2)
         run: |
-          ./run-dast-scan.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE --config registry_v2_authenticated.yaml --tag $RAPIDAST_TAG --authEnabled true
+          GCS_ARGS=""
+          if [ -f "${{ runner.temp }}/gcs-key.json" ]; then
+            GCS_ARGS="--gcsKeyFile ${{ runner.temp }}/gcs-key.json"
+          fi
+          ./run-dast-scan.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE --config registry_v2_authenticated.yaml --tag $RAPIDAST_TAG --authEnabled true $GCS_ARGS
 
       - name: Commit DAST scan results to repository
         uses: ./.github/actions/commit-dast-scan-results
@@ -1458,7 +1488,11 @@ jobs:
 
       - name: Run DAST Scanner (ccompat v7)
         run: |
-          ./run-dast-scan.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE --config ccompat_v7_authenticated.yaml --tag $RAPIDAST_TAG --authEnabled true
+          GCS_ARGS=""
+          if [ -f "${{ runner.temp }}/gcs-key.json" ]; then
+            GCS_ARGS="--gcsKeyFile ${{ runner.temp }}/gcs-key.json"
+          fi
+          ./run-dast-scan.sh --cluster $CLUSTER_NAME --namespace $NAMESPACE --config ccompat_v7_authenticated.yaml --tag $RAPIDAST_TAG --authEnabled true $GCS_ARGS
 
       - name: Commit DAST scan results to repository
         uses: ./.github/actions/commit-dast-scan-results

--- a/run-dast-scan.sh
+++ b/run-dast-scan.sh
@@ -6,7 +6,7 @@ show_usage() {
     local script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     local rapidast_templates_dir="$script_dir/templates/rapidast"
     
-    echo "Usage: $0 [--cluster <cluster_name>] --namespace <namespace> [--config <config_file>] [--tag <rapidast_tag>] [--authEnabled <true|false>]"
+    echo "Usage: $0 [--cluster <cluster_name>] --namespace <namespace> [--config <config_file>] [--tag <rapidast_tag>] [--authEnabled <true|false>] [--gcsKeyFile <path>]"
     echo ""
     echo "This script runs RapiDAST (Rapid DAST) security scanning against a deployed application."
     echo "The target application URL should be configured in the provided rapidast YAML configuration file."
@@ -31,10 +31,13 @@ show_usage() {
     
     echo "  --tag               Optional. Git branch/tag of rapidast to use (default: development)"
     echo "  --authEnabled       Optional. Enable OAuth2 authentication (true|false). When enabled, automatically derives auth settings."
+    echo "  --gcsKeyFile        Optional. Path to Google Cloud Storage service account key file. When provided, scan results"
+    echo "                      are exported to the ProdSec central storage bucket (secaut-bucket)."
     echo ""
     echo "Example: $0 --cluster okd419 --namespace testns1"
     echo "Example: $0 --cluster okd419 --namespace testns1 --config registry_v3_authenticated.yaml --tag 2.12.1"
     echo "Example: $0 --cluster okd419 --namespace testns1 --authEnabled true"
+    echo "Example: $0 --cluster okd419 --namespace testns1 --gcsKeyFile /path/to/gcs-key.json"
 }
 
 ACCESS_TOKEN=""
@@ -164,6 +167,7 @@ NAMESPACE=""
 CONFIG_FILE=""
 RAPIDAST_TAG="development"
 AUTH_ENABLED="false"
+GCS_KEY_FILE=""
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -185,6 +189,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --authEnabled)
             AUTH_ENABLED="$2"
+            shift 2
+            ;;
+        --gcsKeyFile)
+            GCS_KEY_FILE="$2"
             shift 2
             ;;
         -h|--help)
@@ -221,6 +229,14 @@ if [ -n "$AUTH_ENABLED" ] && [ "$AUTH_ENABLED" != "true" ] && [ "$AUTH_ENABLED" 
     echo "Error: --authEnabled must be 'true' or 'false'"
     show_usage
     exit 1
+fi
+
+# Validate GCS key file if provided
+if [ -n "$GCS_KEY_FILE" ]; then
+    if [ ! -f "$GCS_KEY_FILE" ]; then
+        echo "Error: GCS key file not found: $GCS_KEY_FILE"
+        exit 1
+    fi
 fi
 
 # Set base domain for URL construction
@@ -344,6 +360,13 @@ export DAST_BASE_URL=$REGISTRY_APP_URL
 RAPIDAST_CONFIG=$DAST_TESTS_DIR/rapidast-config.yaml
 envsubst < $BASE_DIR/templates/rapidast/$CONFIG_FILE > $RAPIDAST_CONFIG
 
+# Inject Google Cloud Storage export configuration if a GCS key file was provided
+if [ -n "$GCS_KEY_FILE" ]; then
+    echo "Configuring Google Cloud Storage export..."
+    GCS_CONFIG="  googleCloudStorage:\n    keyFile: \"$GCS_KEY_FILE\"\n    bucketName: secaut-bucket\n    directory: \"apicurio-registry\""
+    sed -i "/^config:/a\\$GCS_CONFIG" $RAPIDAST_CONFIG
+fi
+
 # Check if Python 3.12+ is available
 if ! command -v python3.12 &> /dev/null; then
     if ! command -v python3 &> /dev/null; then
@@ -370,6 +393,11 @@ if [ -n "$AUTH_TOKEN_URL" ]; then
     echo "OAuth2 Authentication: Enabled (Token URL: $AUTH_TOKEN_URL)"
 else
     echo "OAuth2 Authentication: Disabled"
+fi
+if [ -n "$GCS_KEY_FILE" ]; then
+    echo "GCS Export: Enabled (bucket: secaut-bucket, directory: apicurio-registry)"
+else
+    echo "GCS Export: Disabled"
 fi
 echo "Available application URLs:"
 echo "  Registry App:  $REGISTRY_APP_URL"


### PR DESCRIPTION
## Summary
- Add `--gcsKeyFile` option to `run-dast-scan.sh` that injects Google Cloud Storage export
  configuration into the RapiDAST config at runtime, enabling upload of scan results to the
  ProdSec central storage bucket (`secaut-bucket/apicurio-registry`).
- Update the test-registry-release workflow to write the `GCS_SA_KEY` secret to a temp file and
  pass it to the DAST scan script, only when `isDownstream` is `true`.

## Notes
- Requires a new repository secret `GCS_SA_KEY` containing the full JSON contents of the GCS
  service account key file provided by Product Security.
- No changes to the RapiDAST config templates — the GCS config block is injected at runtime only
  when the `--gcsKeyFile` flag is provided.

## Test plan
- [ ] Verify upstream (non-downstream) DAST scans still run without GCS export
- [ ] Verify downstream DAST scans export results to GCS once `GCS_SA_KEY` secret is configured
- [ ] Verify `run-dast-scan.sh --help` shows the new `--gcsKeyFile` option