### PR TITLE
fix: update org references from Apicurio to ApicurioTesting

### DIFF
--- a/.github/actions/commit-dast-scan-results/action.yml
+++ b/.github/actions/commit-dast-scan-results/action.yml
@@ -28,7 +28,7 @@ runs:
 
         # Clone the results repository
         rm -rf $RESULTS_DIR
-        git clone https://${{ inputs.github-token }}@github.com/Apicurio/apicurio-testing-results.git $RESULTS_DIR
+        git clone https://${{ inputs.github-token }}@github.com/ApicurioTesting/apicurio-testing-results.git $RESULTS_DIR
         pushd .
         cd $RESULTS_DIR
         # Configure git for the results repository

--- a/.github/actions/commit-integration-test-results/action.yml
+++ b/.github/actions/commit-integration-test-results/action.yml
@@ -25,7 +25,7 @@ runs:
 
         # Clone the results repository
         rm -rf $RESULTS_DIR
-        git clone https://${{ inputs.github-token }}@github.com/Apicurio/apicurio-testing-results.git $RESULTS_DIR
+        git clone https://${{ inputs.github-token }}@github.com/ApicurioTesting/apicurio-testing-results.git $RESULTS_DIR
         pushd .
         cd $RESULTS_DIR
         # Configure git for the results repository

--- a/.github/actions/commit-pod-logs/action.yml
+++ b/.github/actions/commit-pod-logs/action.yml
@@ -25,7 +25,7 @@ runs:
 
         # Clone the results repository
         rm -rf $RESULTS_DIR
-        git clone https://${{ inputs.github-token }}@github.com/Apicurio/apicurio-testing-results.git $RESULTS_DIR
+        git clone https://${{ inputs.github-token }}@github.com/ApicurioTesting/apicurio-testing-results.git $RESULTS_DIR
         pushd .
         cd $RESULTS_DIR
         # Configure git for the results repository

--- a/.github/actions/commit-ui-test-results/action.yml
+++ b/.github/actions/commit-ui-test-results/action.yml
@@ -25,7 +25,7 @@ runs:
 
         # Clone the results repository
         rm -rf $RESULTS_DIR
-        git clone https://${{ inputs.github-token }}@github.com/Apicurio/apicurio-testing-results.git $RESULTS_DIR
+        git clone https://${{ inputs.github-token }}@github.com/ApicurioTesting/apicurio-testing-results.git $RESULTS_DIR
         pushd .
         cd $RESULTS_DIR
         # Configure git for the results repository

--- a/.github/actions/commit-workflow-metadata/action.yml
+++ b/.github/actions/commit-workflow-metadata/action.yml
@@ -22,7 +22,7 @@ runs:
 
         # Clone the results repository
         rm -rf $RESULTS_DIR
-        git clone https://${{ inputs.github-token }}@github.com/Apicurio/apicurio-testing-results.git $RESULTS_DIR
+        git clone https://${{ inputs.github-token }}@github.com/ApicurioTesting/apicurio-testing-results.git $RESULTS_DIR
         pushd .
         cd $RESULTS_DIR
         # Configure git for the results repository

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ When adding new test configurations:
 
 ## Support
 
-- **Issues:** Report issues in the [GitHub Issues](https://github.com/Apicurio/apicurio-testing/issues)
+- **Issues:** Report issues in the [GitHub Issues](https://github.com/ApicurioTesting/apicurio-testing/issues)
 - **Discussions:** Use GitHub Discussions for questions
 - **Slack:** #apicurio on CNCF Slack
 

--- a/load-cache.sh
+++ b/load-cache.sh
@@ -47,13 +47,13 @@ if [ "$REMOVE_CACHE" = true ]; then
 fi
 if [ ! -d "$CACHE_DIR" ]; then
   if [ -n "$GITHUB_TOKEN" ]; then
-    git clone --depth 1 "https://$GITHUB_TOKEN@github.com/Apicurio/apicurio-testing-cache.git" "$CACHE_DIR"
+    git clone --depth 1 "https://$GITHUB_TOKEN@github.com/ApicurioTesting/apicurio-testing-cache.git" "$CACHE_DIR"
     pushd "$CACHE_DIR" > /dev/null || error_exit "Failed to enter directory."
     git config user.name "apicurio-ci"
     git config user.email "apicurio.ci@gmail.com"
     git config pull.rebase true
   else
-    git clone --depth 1 git@github.com:Apicurio/apicurio-testing-cache.git "$CACHE_DIR"
+    git clone --depth 1 git@github.com:ApicurioTesting/apicurio-testing-cache.git "$CACHE_DIR"
     pushd "$CACHE_DIR" > /dev/null || error_exit "Failed to enter directory."
     git config pull.rebase true
   fi


### PR DESCRIPTION
## Summary
- Updated all hardcoded GitHub organization references after transferring repositories
  from `Apicurio` to `ApicurioTesting`
- 5 GitHub Action files: clone URLs for `apicurio-testing-results`
- `load-cache.sh`: HTTPS and SSH clone URLs for `apicurio-testing-cache`
- `README.md`: GitHub Issues link

## Test plan
- [ ] Verify GitHub Actions workflows can clone `apicurio-testing-results` from the new org
- [ ] Verify `load-cache.sh` can clone `apicurio-testing-cache` from the new org
- [ ] Verify README issues link resolves correctly